### PR TITLE
feat: 토너먼트 대진 결과 메인

### DIFF
--- a/Frontend/src/App.tsx
+++ b/Frontend/src/App.tsx
@@ -12,53 +12,55 @@ import Setting from "./pages/setting/Setting.tsx";
 import History_Home from "./pages/gameHistory/History_Home.tsx";
 import Tournament from "./pages/Tournament/Tournament.tsx";
 import Waiting from "./pages/Tournament/Waiting.tsx";
-import Invitation from "./pages/Tournament/Invitation.tsx"
+import Invitation from "./pages/Tournament/Invitation.tsx";
+import Matching from "./pages/Tournament/Matching.tsx";
 
 const App = () => {
-	useEffect(() => {
+  useEffect(() => {
     const lockWindowSize = () => {
-	window.resizeTo(800, 600);
+      window.resizeTo(800, 600);
     };
 
     window.addEventListener("resize", lockWindowSize);
     lockWindowSize(); // 실행 시 즉시 크기 고정
 
     return () => {
-		window.removeEventListener("resize", lockWindowSize);
+      window.removeEventListener("resize", lockWindowSize);
     };
-	}, []);
+  }, []);
 
-	return (
+  return (
     <>
-	<GlobalStyle />
-	<Router>
-		<Routes>
-			{/* 메인 홈페이지 */}
-			<Route path="/" element={<Login />} />
-			<Route path="/Register" element={<Register />} />
-			<Route path="/Home" element={<Home />} />
-			{/* 게임 선택 홈페이지 */}
-			<Route path="/Select_GameOption" element={<Select_GameOption />} />
-			<Route
-				path="/Select_GameMode_Auto"
-				element={<Select_GameMode_Auto />}
-			/>
-			<Route
-				path="/Select_GameMode_Custom"
-				element={<Select_GameMode_Custom />}
-			/>
-			{/* 사용자 관련 유틸 */}
-			<Route path="/Setting" element={<Setting />} />
-			<Route path="/History_Home" element={<History_Home />} />
-			{/* <Route path="/History_1vs1" element={<History_1vs1 />} /> */}
-			{/* 토너먼트 */}
-			<Route path="/Tournament" element={<Tournament />} />
-			<Route path="/Waiting" element={<Waiting />} />
-			<Route path="/Invitation" element={<Invitation />} />
-		</Routes>
-	</Router>
+      <GlobalStyle />
+      <Router>
+        <Routes>
+          {/* 메인 홈페이지 */}
+          <Route path="/" element={<Login />} />
+          <Route path="/Register" element={<Register />} />
+          <Route path="/Home" element={<Home />} />
+          {/* 게임 선택 홈페이지 */}
+          <Route path="/Select_GameOption" element={<Select_GameOption />} />
+          <Route
+            path="/Select_GameMode_Auto"
+            element={<Select_GameMode_Auto />}
+          />
+          <Route
+            path="/Select_GameMode_Custom"
+            element={<Select_GameMode_Custom />}
+          />
+          {/* 사용자 관련 유틸 */}
+          <Route path="/Setting" element={<Setting />} />
+          <Route path="/History_Home" element={<History_Home />} />
+          {/* <Route path="/History_1vs1" element={<History_1vs1 />} /> */}
+          {/* 토너먼트 */}
+          <Route path="/Tournament" element={<Tournament />} />
+          <Route path="/Waiting" element={<Waiting />} />
+          <Route path="/Invitation" element={<Invitation />} />
+          <Route path="/TournamentMain" element={<Matching />} />
+        </Routes>
+      </Router>
     </>
-	);
+  );
 };
 
 export default App;

--- a/Frontend/src/pages/Tournament/Matching.ts
+++ b/Frontend/src/pages/Tournament/Matching.ts
@@ -8,7 +8,7 @@ export const Wrapper = styled.div`
 export const ProfileOverlay = styled.div`
   position: absolute;
   top: 150px;
-  left: 35px;
+  left: 20px;
   z-index: 10;
   display: flex;
   justify-content: center;
@@ -19,7 +19,7 @@ export const UserGrid = styled.div`
   display: grid;
   grid-template-columns: repeat(2, 100px);
   grid-template-rows: repeat(2, auto);
-  gap: 90px 240px;
+  gap: 120px 270px;
 `;
 
 export const UserProfile = styled.div<{ isReady: boolean }>`
@@ -28,8 +28,8 @@ export const UserProfile = styled.div<{ isReady: boolean }>`
   align-items: center;
 
   img {
-    width: 80px;
-    height: 80px;
+    width: 70px;
+    height: 70px;
     border-radius: 50%;
     border: 4px solid transparent;
     object-fit: cover;
@@ -56,7 +56,31 @@ export const SixtyfourFont = createGlobalStyle`
 
 export const UserName = styled.span`
   margin-top: 8px;
-  font-size: 14px;
+  font-size: 12px;
   color: white;
   font-family: "Sixtyfour", sans-serif;
+`;
+
+export const LineWrapper = styled.div`
+  position: relative;
+`;
+
+export const VerticalLine = styled.div<{ left: string }>`
+  position: absolute;
+  top: 108px;
+  left: ${({ left }) => left};
+  width: 1.1px;
+  height: 100px;
+  background-color: white;
+  z-index: 5;
+`;
+
+export const HorizontalLine = styled.div<{ left: string }>`
+  position: absolute;
+  top: 156px;
+  left: ${({ left }) => left};
+  width: 85px;
+  height: 1.1px;
+  background-color: white;
+  z-index: 5;
 `;

--- a/Frontend/src/pages/Tournament/Matching.ts
+++ b/Frontend/src/pages/Tournament/Matching.ts
@@ -1,0 +1,62 @@
+import styled, { css, createGlobalStyle } from "styled-components";
+
+export const Wrapper = styled.div`
+  position: relative;
+  width: 100%;
+`;
+
+export const ProfileOverlay = styled.div`
+  position: absolute;
+  top: 150px;
+  left: 35px;
+  z-index: 10;
+  display: flex;
+  justify-content: center;
+  pointer-events: none;
+`;
+
+export const UserGrid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(2, 100px);
+  grid-template-rows: repeat(2, auto);
+  gap: 90px 240px;
+`;
+
+export const UserProfile = styled.div<{ isReady: boolean }>`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+
+  img {
+    width: 80px;
+    height: 80px;
+    border-radius: 50%;
+    border: 4px solid transparent;
+    object-fit: cover;
+    transition: border-color 0.3s ease;
+
+    ${({ isReady }) =>
+      isReady &&
+      css`
+        border-color: #00ff00;
+      `}
+  }
+`;
+
+export const UserImage = styled.img``;
+
+export const SixtyfourFont = createGlobalStyle`
+  @font-face {
+    font-family: 'Sixtyfour';
+    src: url('../../assets/fonts/Sixtyfour.ttf') format('truetype');
+    font-weight: normal;
+    font-style: normal;
+  }
+`;
+
+export const UserName = styled.span`
+  margin-top: 8px;
+  font-size: 14px;
+  color: white;
+  font-family: "Sixtyfour", sans-serif;
+`;

--- a/Frontend/src/pages/Tournament/Matching.tsx
+++ b/Frontend/src/pages/Tournament/Matching.tsx
@@ -1,0 +1,46 @@
+import React, { useState } from "react";
+import Tournament from "./Tournament.tsx";
+import BasicProfile1 from "../../assets/image/BasicProfile1.png";
+import BasicProfile2 from "../../assets/image/BasicProfile2.png";
+
+import {
+  Wrapper,
+  ProfileOverlay,
+  UserGrid,
+  UserProfile,
+  UserImage,
+  UserName,
+} from "./Matching";
+
+const mockUsers = [
+  { id: 1, name: "PONG", profileImage: BasicProfile1 },
+  { id: 2, name: "DING", profileImage: BasicProfile2 },
+  { id: 3, name: "PING", profileImage: BasicProfile1 },
+  { id: 4, name: "DONG", profileImage: BasicProfile2 },
+];
+
+const Matching = () => {
+  const [isReady, setIsReady] = useState(false);
+
+  const toggleReadyState = () => {
+    setIsReady((prev) => !prev);
+  };
+
+  return (
+    <Wrapper>
+      <ProfileOverlay>
+        <UserGrid>
+          {mockUsers.map((user) => (
+            <UserProfile key={user.id} isReady={isReady}>
+              <UserImage src={user.profileImage} alt={user.name} />
+              <UserName>{user.name}</UserName>
+            </UserProfile>
+          ))}
+        </UserGrid>
+      </ProfileOverlay>
+      <Tournament onReadyClick={toggleReadyState} />
+    </Wrapper>
+  );
+};
+
+export default Matching;

--- a/Frontend/src/pages/Tournament/Matching.tsx
+++ b/Frontend/src/pages/Tournament/Matching.tsx
@@ -10,6 +10,9 @@ import {
   UserProfile,
   UserImage,
   UserName,
+  LineWrapper,
+  VerticalLine,
+  HorizontalLine,
 } from "./Matching";
 
 const mockUsers = [
@@ -29,14 +32,22 @@ const Matching = () => {
   return (
     <Wrapper>
       <ProfileOverlay>
-        <UserGrid>
-          {mockUsers.map((user) => (
-            <UserProfile key={user.id} isReady={isReady}>
-              <UserImage src={user.profileImage} alt={user.name} />
-              <UserName>{user.name}</UserName>
-            </UserProfile>
-          ))}
-        </UserGrid>
+        <LineWrapper>
+          {/* 왼쪽 세로선 + 가로선 */}
+          <VerticalLine left="46px" />
+          <HorizontalLine left="46px" />
+          {/* 오른쪽 세로선 + 가로선 */}
+          <VerticalLine left="420px" />
+          <HorizontalLine left="335px" />{" "}
+          <UserGrid>
+            {mockUsers.map((user) => (
+              <UserProfile key={user.id} isReady={isReady}>
+                <UserImage src={user.profileImage} alt={user.name} />
+                <UserName>{user.name}</UserName>
+              </UserProfile>
+            ))}
+          </UserGrid>
+        </LineWrapper>
       </ProfileOverlay>
       <Tournament onReadyClick={toggleReadyState} />
     </Wrapper>


### PR DESCRIPTION
## 🔗 반영 브랜치
ex. (#9) yeeun/TournamentVS -> dev

## 📝 작업 내용
### 1. 대진표 4강 대기화면 `(/Matching)`
- `Tournament` 위에 겹쳐지는 사용자 프로필 UI(`Matching.tsx`) 추가
- 사용자 이름 및 프로필 이미지 2행 2열 `grid` 구조로 정렬
- `READY` 버튼 클릭 시 사용자 프로필 테두리 색상이 초록색으로 변경되도록 구현
- 사용자 이름에 커스텀 폰트 `Sixtyfour` 적용
### 2. 대진표 가로/세로 선 추가 `(/Matching)`
- 사용자 프로필 **상하를 연결하는 세로선** 2개 추가
- 세로선 중앙에 **좌우로 뻗는 가로선** 2개 추가 → 대결 구조 표현
- 선 굵기: `1.1px`로 통일, 배경과 잘 어울리는 흰색 사용

### 📸 스크린샷 (선택)
**1️⃣ 토너먼트 대진표 4강 Main 화면**
<img width="1191" alt="스크린샷 2025-03-25 오전 12 52 35" src="https://github.com/user-attachments/assets/6da89a2d-d624-43c1-81b1-09353ff223f2" />
- 사용자 프로필 이미지는 **버튼 형태로 구현하지 않고** `img` 태그를 사용한 시각적 구성으로 처리함
  - 프로필은 단순한 **시각 강조 요소**이며 해당 페이지에서 클릭 이벤트가 없기 때문에 굳이 버튼으로 만들지 않음
- 2명씩 대결하여 이긴 사람을 표시해야 해서 중간에 들어갈 공간을 비워두고 개발 진행
- 위치나 라인 배치는 **디자인 완성 시점에 미세 조정** 예정

**2️⃣ 대진표 선 구현**
<img width="1190" alt="스크린샷 2025-03-25 오전 1 43 43" src="https://github.com/user-attachments/assets/988aa706-1917-4a42-b863-bf59412b01ce" />
- 가로 및 세로 선은 처음에는 Figma에서 이미지로 저장할지 고민했지만, 화면 확대/축소 시 이미지 크기나 위치가 어긋날 수 있다는 점을 고려해 CSS로 직접 선을 구현하는 방식으로 결정