### PR TITLE
refactor: 토너먼트 페이지 컴포넌트 분리

### DIFF
--- a/Frontend/src/pages/Tournament/MatchResult.tsx
+++ b/Frontend/src/pages/Tournament/MatchResult.tsx
@@ -1,33 +1,25 @@
 import React from "react";
-import Tournament from "./Tournament.tsx";
 import { useNavigate } from "react-router-dom";
+import Tournament from "./Tournament.tsx";
+import { Wrapper, LineWrapper } from "./Matching";
+
+import {
+  ResultProfileOverlay,
+  ExitButtonWrapper,
+  ExitImage,
+} from "./MatchResult";
+
+// 공통 컴포넌트 import
+import FinalResultDisplay from "./components/FinalResultDisplay";
+import MatchLines from "./components/MatchLines";
+import FourUsersGrid from "./components/FourUsersGrid";
+
+// 이미지 import
 import BasicProfile1 from "../../assets/image/BasicProfile1.png";
 import BasicProfile2 from "../../assets/image/BasicProfile2.png";
 import ExitButtonImg from "../../assets/image/ExitButton.png";
 
-import {
-  Wrapper,
-  UserGrid,
-  UserProfile,
-  UserImage,
-  UserName,
-  LineWrapper,
-  VerticalLine,
-  HorizontalLine,
-} from "./Matching";
-
-import {
-  CongratsText,
-  WinnerLabel,
-  FinalWinnerWrapper,
-  OpponentWrapper,
-  ExitButtonWrapper,
-  ExitImage,
-  ResultProfileOverlay,
-  VsText,
-} from "./MatchResult";
-
-// 임시 유저 정보 (4강)
+// 임시 사용자 데이터
 const mockUsers = [
   { id: 1, name: "PONG", profileImage: BasicProfile1 },
   { id: 2, name: "DING", profileImage: BasicProfile2 },
@@ -35,13 +27,12 @@ const mockUsers = [
   { id: 4, name: "DONG", profileImage: BasicProfile2 },
 ];
 
-// 2강 진출자
 const mockWinners = [
   { id: 1, name: "PONG", profileImage: BasicProfile1 },
   { id: 2, name: "DING", profileImage: BasicProfile2 },
 ];
 
-// 최종 승자 임시 api (요소 위치 조절)
+// 현재는 DING이 이겼다고 가정한 상태 (Winner 텍스트 위치 변경 확인)
 const finalWinner = { id: 2, name: "DING", profileImage: BasicProfile2 };
 // const finalWinner = { id: 1, name: "PONG", profileImage: BasicProfile1 };
 
@@ -49,43 +40,14 @@ const MatchResult = () => {
   const navigate = useNavigate();
 
   const loser = mockWinners.find((user) => user.id !== finalWinner.id);
-  const isLeftWinner = finalWinner.id === mockWinners[0].id;
 
   return (
     <Wrapper>
       <ResultProfileOverlay>
         <LineWrapper>
-          <CongratsText>Congrats!</CongratsText>
-          <WinnerLabel isLeft={isLeftWinner}>WINNER!</WinnerLabel>
-          <FinalWinnerWrapper isLeft={isLeftWinner}>
-            <UserProfile isReady={false}>
-              <UserImage
-                src={finalWinner.profileImage}
-                alt={finalWinner.name}
-              />
-              <UserName>{finalWinner.name}</UserName>
-            </UserProfile>
-          </FinalWinnerWrapper>
-          <OpponentWrapper isLeft={isLeftWinner}>
-            <UserProfile isReady={false}>
-              <UserImage src={loser?.profileImage} alt={loser?.name} />
-              <UserName>{loser?.name}</UserName>
-            </UserProfile>
-          </OpponentWrapper>
-          <VsText isLeft={isLeftWinner}>VS</VsText>
-          <VerticalLine left="46px" />
-          <HorizontalLine left="46px" />
-          <VerticalLine left="420px" />
-          <HorizontalLine left="335px" />
-          {/* 4강 유저 */}
-          <UserGrid>
-            {mockUsers.map((user) => (
-              <UserProfile key={user.id} isReady={false}>
-                <UserImage src={user.profileImage} alt={user.name} />
-                <UserName>{user.name}</UserName>
-              </UserProfile>
-            ))}
-          </UserGrid>
+          {loser && <FinalResultDisplay winner={finalWinner} loser={loser} />}
+          <MatchLines />
+          <FourUsersGrid users={mockUsers} />
         </LineWrapper>
       </ResultProfileOverlay>
       <Tournament

--- a/Frontend/src/pages/Tournament/Matching.tsx
+++ b/Frontend/src/pages/Tournament/Matching.tsx
@@ -1,23 +1,17 @@
 import React, { useState, useEffect } from "react";
 import Tournament from "./Tournament.tsx";
-import { LINE_POSITION } from "./Matching.ts";
+import { Wrapper, ProfileOverlay, LineWrapper } from "./Matching";
+
+// 공통 컴포넌트 import
+import SemiFinalGrid from "./components/SemiFinalGrid";
+import FourUsersGrid from "./components/FourUsersGrid";
+import MatchLines from "./components/MatchLines";
+
+// 사용자 데이터 import
 import BasicProfile1 from "../../assets/image/BasicProfile1.png";
 import BasicProfile2 from "../../assets/image/BasicProfile2.png";
 
-import {
-  Wrapper,
-  ProfileOverlay,
-  UserGrid,
-  UserProfile,
-  UserImage,
-  UserName,
-  LineWrapper,
-  VerticalLine,
-  HorizontalLine,
-  WinnerGrid,
-  VsText,
-} from "./Matching";
-
+// 임시 유저 데이터
 const mockUsers = [
   { id: 1, name: "PONG", profileImage: BasicProfile1 },
   { id: 2, name: "DING", profileImage: BasicProfile2 },
@@ -30,7 +24,6 @@ const mockWinners = [
   { id: 2, name: "DING", profileImage: BasicProfile2 },
 ];
 
-// 현재 로그인된 사용자라고 가정 (예: Ping)
 const currentUserId = 3;
 
 const Matching = () => {
@@ -50,7 +43,6 @@ const Matching = () => {
       },
     };
 
-    // 실제 WebSocket이 아닌 mock 수신 처리
     handleReceiveReady(mockSendPayload.data);
   };
 
@@ -61,7 +53,6 @@ const Matching = () => {
     }));
   };
 
-  // mock 수신 테스트 (예: 4초 뒤에 Ding 준비됨)
   useEffect(() => {
     const timeout = setTimeout(() => {
       handleReceiveReady({ user_id: 2 });
@@ -73,33 +64,9 @@ const Matching = () => {
     <Wrapper>
       <ProfileOverlay>
         <LineWrapper>
-          {/* 중앙 상단 승자 이미지 */}
-          <WinnerGrid>
-            {mockWinners.map((user) => (
-              <UserProfile key={user.id} isReady={!!readyStates[user.id]}>
-                <UserImage src={user.profileImage} alt={user.name} />
-                <UserName>{user.name}</UserName>
-              </UserProfile>
-            ))}
-          </WinnerGrid>
-          <VsText>VS</VsText>
-          {/* 대진표 구분선 - 왼쪽 */}
-          <VerticalLine left={LINE_POSITION.LEFT_VERTICAL} />
-          <HorizontalLine left={LINE_POSITION.LEFT_HORIZONTAL} />
-          {/* 대진표 구분선 -  */}
-          <VerticalLine left={LINE_POSITION.RIGHT_VERTICAL} />
-          <HorizontalLine left={LINE_POSITION.RIGHT_HORIZONTAL} />
-          <UserGrid>
-            {mockUsers.map((user) => (
-              <UserProfile
-                key={user.id}
-                isReady={false} // 4강 유저는 항상 false (테두리 변경 비활성화)
-              >
-                <UserImage src={user.profileImage} alt={user.name} />
-                <UserName>{user.name}</UserName>
-              </UserProfile>
-            ))}
-          </UserGrid>
+          <SemiFinalGrid users={mockWinners} readyStates={readyStates} />
+          <MatchLines />
+          <FourUsersGrid users={mockUsers} />
         </LineWrapper>
       </ProfileOverlay>
       <Tournament onReadyClick={handleReadyClick} />

--- a/Frontend/src/pages/Tournament/components/FinalResultDisplay.tsx
+++ b/Frontend/src/pages/Tournament/components/FinalResultDisplay.tsx
@@ -1,0 +1,41 @@
+// components/FinalResultDisplay.tsx
+import React from "react";
+import {
+  CongratsText,
+  WinnerLabel,
+  FinalWinnerWrapper,
+  OpponentWrapper,
+  VsText,
+} from "../MatchResult";
+import UserProfileCard from "./UserProfileCard";
+
+interface User {
+  id: number;
+  name: string;
+  profileImage: string;
+}
+
+interface Props {
+  winner: User;
+  loser: User;
+}
+
+const FinalResultDisplay: React.FC<Props> = ({ winner, loser }) => {
+  const isLeft = winner.id < loser.id;
+
+  return (
+    <>
+      <CongratsText>Congrats!</CongratsText>
+      <WinnerLabel isLeft={isLeft}>WINNER!</WinnerLabel>
+      <FinalWinnerWrapper isLeft={isLeft}>
+        <UserProfileCard user={winner} />
+      </FinalWinnerWrapper>
+      <OpponentWrapper isLeft={isLeft}>
+        <UserProfileCard user={loser} />
+      </OpponentWrapper>
+      <VsText isLeft={isLeft}>VS</VsText>
+    </>
+  );
+};
+
+export default FinalResultDisplay;

--- a/Frontend/src/pages/Tournament/components/FourUsersGrid.tsx
+++ b/Frontend/src/pages/Tournament/components/FourUsersGrid.tsx
@@ -1,0 +1,24 @@
+// components/FourUsersGrid.tsx
+import React from "react";
+import { UserGrid } from "../Matching";
+import UserProfileCard from "./UserProfileCard";
+
+interface User {
+  id: number;
+  name: string;
+  profileImage: string;
+}
+
+interface Props {
+  users: User[];
+}
+
+const FourUsersGrid: React.FC<Props> = ({ users }) => (
+  <UserGrid>
+    {users.map((user) => (
+      <UserProfileCard key={user.id} user={user} />
+    ))}
+  </UserGrid>
+);
+
+export default FourUsersGrid;

--- a/Frontend/src/pages/Tournament/components/MatchLines.tsx
+++ b/Frontend/src/pages/Tournament/components/MatchLines.tsx
@@ -1,0 +1,14 @@
+// components/MatchLines.tsx
+import React from "react";
+import { LINE_POSITION, VerticalLine, HorizontalLine } from "../Matching";
+
+const MatchLines: React.FC = () => (
+  <>
+    <VerticalLine left={LINE_POSITION.LEFT_VERTICAL} />
+    <HorizontalLine left={LINE_POSITION.LEFT_HORIZONTAL} />
+    <VerticalLine left={LINE_POSITION.RIGHT_VERTICAL} />
+    <HorizontalLine left={LINE_POSITION.RIGHT_HORIZONTAL} />
+  </>
+);
+
+export default MatchLines;

--- a/Frontend/src/pages/Tournament/components/SemiFinalGrid.tsx
+++ b/Frontend/src/pages/Tournament/components/SemiFinalGrid.tsx
@@ -1,0 +1,32 @@
+// components/SemiFinalGrid.tsx
+import React from "react";
+import { WinnerGrid, VsText } from "../Matching";
+import UserProfileCard from "./UserProfileCard";
+
+interface User {
+  id: number;
+  name: string;
+  profileImage: string;
+}
+
+interface Props {
+  users: User[];
+  readyStates?: { [userId: number]: boolean };
+}
+
+const SemiFinalGrid: React.FC<Props> = ({ users, readyStates = {} }) => (
+  <>
+    <WinnerGrid>
+      {users.map((user) => (
+        <UserProfileCard
+          key={user.id}
+          user={user}
+          isReady={!!readyStates[user.id]}
+        />
+      ))}
+    </WinnerGrid>
+    <VsText>VS</VsText>
+  </>
+);
+
+export default SemiFinalGrid;

--- a/Frontend/src/pages/Tournament/components/UserProfileCard.tsx
+++ b/Frontend/src/pages/Tournament/components/UserProfileCard.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+import { UserProfile, UserImage, UserName } from "../Matching";
+
+interface User {
+  id: number;
+  name: string;
+  profileImage: string;
+}
+
+interface Props {
+  user: User;
+  isReady?: boolean;
+}
+
+const UserProfileCard: React.FC<Props> = ({ user, isReady = false }) => (
+  <UserProfile isReady={isReady}>
+    <UserImage src={user.profileImage} alt={user.name} />
+    <UserName>{user.name}</UserName>
+  </UserProfile>
+);
+
+export default UserProfileCard;


### PR DESCRIPTION
## 🔗 반영 브랜치

ex. (#24) yeeun/TournamentVS4 -> dev

## 📝 작업 내용
- `Matching.tsx`, `MatchResult.tsx` 내 중복되는 토너먼트 UI 요소들을 컴포넌트로 분리하여 `components/` 폴더에 정리했습니다.
- 공통 요소를 분리하여 `Frontend/src/pages/Tournament/components` 경로에 다음 컴포넌트를 새로 생성했습니다.
  - `UserProfileCard.tsx`: 유저 프로필 카드 컴포넌트
  - `FourUsersGrid.tsx`: 4강 사용자 그리드
  - `SemiFinalGrid.tsx`: 2강 사용자 그리드 및 VS 표시
  - `FinalResultDisplay.tsx`: 최종 승자 vs 패자 결과 표시
  - `MatchLines.tsx`: 대진표 라인 요소 (세로/가로 선)

## 💬 리뷰 요구사항(선택)
> 기존 기능 및 스타일은 그대로 유지되도록 리팩토링만 진행했습니다. 테스트 결과 기존 UI와 동일하게 정상 동작되는 것을 확인하였습니다.

- 제가 한 컴포넌트 분리 방식 외 다른 효율적인 방식이 있다면 코멘트 남겨주실 수 있으신가요?
