### PR TITLE
feat: 상대방 Ready 상태 반영 및 Toast 표시

### DIFF
--- a/Frontend/src/pages/Tournament/Matching.ts
+++ b/Frontend/src/pages/Tournament/Matching.ts
@@ -1,5 +1,6 @@
-import styled, { css } from "styled-components";
+import styled, { createGlobalStyle, css } from "styled-components";
 import { LINE_HEIGHT, LINE_COLOR } from "./LineConstants";
+import { ToastContainer } from "react-toastify";
 
 export const Wrapper = styled.div`
   position: relative;
@@ -100,4 +101,34 @@ export const ExitImage = styled.img`
   width: 200px;
   height: auto;
   object-fit: contain;
+`;
+
+export const CustomToastContainer = styled(ToastContainer)`
+  margin-left: 50px;
+`;
+
+export const ToastStyle = createGlobalStyle`
+  .custom-toast {
+    width: 180px !important;
+    min-width: unset !important;
+    max-width: 180px !important;
+    padding: 6px 10px !important;
+    font-size: 13px !important;
+    border-radius: 5px !important;
+    background-color: white !important;
+    color: black !important;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+    display: flex;
+    align-items: center;
+
+    .Toastify__toast-icon {
+      width: 16px !important;
+      height: 16px !important;
+      margin-right: 6px !important;
+    }
+
+    .Toastify__progress-bar {
+      height: 3px !important;
+    }
+  }
 `;

--- a/Frontend/src/pages/Tournament/Matching.tsx
+++ b/Frontend/src/pages/Tournament/Matching.tsx
@@ -1,6 +1,8 @@
-import React, { useState, useEffect } from "react";
+import React, { useState } from "react";
 import Tournament from "./Tournament.tsx";
 import { useNavigate } from "react-router-dom";
+
+// styles
 import {
   Wrapper,
   ProfileOverlay,
@@ -9,14 +11,22 @@ import {
   ExitImage,
   ExitButtonWrapper,
 } from "./Matching";
+
+// components
 import SemiFinalGrid from "./components/SemiFinalGrid/index";
 import FourUsersGrid from "./components/FourUsersGrid";
 import MatchLines from "./components/MatchLines";
 import VsText from "./components/\bVsText/\bindex.tsx";
+import { ToastStyle, CustomToastContainer } from "./Matching";
 
+// Images
 import BasicProfile1 from "../../assets/image/BasicProfile1.png";
 import BasicProfile2 from "../../assets/image/BasicProfile2.png";
 import ExitButtonImg from "../../assets/image/ExitButton.png";
+
+// etc
+import { toast } from "react-toastify";
+import "react-toastify/dist/ReactToastify.css";
 
 // 임시 유저 데이터
 const mockUsers = [
@@ -45,37 +55,34 @@ const Matching = () => {
 
   const navigate = useNavigate();
 
-  // 임시 API 응답 시뮬레이션 (이긴 사람을 DING으로 가정)
-  useEffect(() => {
-    const timeout = setTimeout(() => {
-      const winnerFromAPI = mockUsers.find((user) => user.name === "DING");
-      setFinalWinner(winnerFromAPI || null);
-      setGameEnded(true);
-    }, 5000); // 예시: 5초 뒤 게임 끝
-    return () => clearTimeout(timeout);
-  }, []);
-
-  const handleReadyClick = () => {
-    const mockSendPayload = {
-      action: "send",
-      category: "game",
-      resource: "ready",
-      data: {
-        tournament_id: 135,
-        match_id: 737,
-        user_id: currentUserId,
-      },
-    };
-
-    handleReceiveReady(mockSendPayload.data);
-  };
-
   const handleReceiveReady = (data: { user_id: number }) => {
     setReadyStates((prev) => ({
       ...prev,
       [data.user_id]: true,
     }));
   };
+
+  const handleReadyClick = () => {
+    // 본인 Ready 처리 (PING)
+    handleReceiveReady({ user_id: currentUserId });
+    // 상대방 Ready 처리 (DING) → 1초 후
+    setTimeout(() => {
+      const opponentId = 2;
+      handleReceiveReady({ user_id: opponentId });
+      // Toast 띄우기
+      setTimeout(() => {
+        toast.success("🏓 곧 게임이 시작됩니다!", {
+          position: "top-center",
+          autoClose: 2000,
+        });
+        // 3초 뒤 게임 화면으로 이동
+        setTimeout(() => {
+          navigate("/GameScreen");
+        }, 3000);
+      }, 100); // 테두리 반영 여유 시간
+    }, 1000);
+  };
+
   return (
     <Wrapper>
       <ProfileOverlay>
@@ -114,6 +121,13 @@ const Matching = () => {
           ) : undefined
         }
       />
+      <CustomToastContainer
+        position="top-center"
+        autoClose={2000}
+        toastClassName="custom-toast"
+        style={{ marginLeft: "10px" }}
+      />
+      <ToastStyle />
     </Wrapper>
   );
 };


### PR DESCRIPTION
## 🔗 반영 브랜치

ex. (#16) yeeun/WaitingGame -> dev 

## 📝 작업 내용
- `Ready` 버튼 클릭 시, 본인(PING)과 상대방(DING)의 준비 상태를 UI에 반영하도록 구현했습니다.
- 준비 상태는 초록색 테두리로 표시되며, 두 유저 모두 준비된 후에만 `Toast` 메시지가 표시됩니다.
- `Toast` 메시지 뜨고 3초 후 `/GameScreen` 화면으로 `navigate`를 사용하여 페이지 이동합니다.
- winner 표시는 해당 기능 구현으로 인해 잠시 주석 처리 상태입니다.

### 📸 스크린샷 (선택)
> `/TournamentMain` 실행 결과
<img width="1194" alt="스크린샷 2025-03-31 오후 4 48 10" src="https://github.com/user-attachments/assets/c664d23c-63ff-40e4-8370-e28ddf029c8b" />

## 💬 리뷰 요구사항(선택)
### Toast 팝업 위치가 고민입니다!
- 지금처럼 Chat 에 가려지지 않도록 검은 배경화면 위에 위치
- 화면 기준 가장 오른쪽(채팅 부분) 위에 위치
