### PR TITLE
fix: GameScreen에서 돌아온 경우에만 승자 텍스트 표시

### DIFF
--- a/Frontend/src/pages/Game/GameScreen.tsx
+++ b/Frontend/src/pages/Game/GameScreen.tsx
@@ -1,46 +1,64 @@
-import { useState } from "react"
-import { motion, AnimatePresence } from "framer-motion"
-import Container from "./components/Container"
-import MenuButton from '../../assets/image/Menu.svg'
-import Score from "./components/Score"
-import Field from "./components/Field"
-import MenuPopup from "./components/MenuPopup"
+import { useState, useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import { motion, AnimatePresence } from "framer-motion";
+import Container from "./components/Container";
+import MenuButton from "../../assets/image/Menu.svg";
+import Score from "./components/Score";
+import Field from "./components/Field";
+import MenuPopup from "./components/MenuPopup";
 
 const GameScreen = () => {
-	const [isOpenMenuPopup, setIsOpenMenuPopup] = useState(false)
+  const [isOpenMenuPopup, setIsOpenMenuPopup] = useState(false);
+  const navigate = useNavigate();
 
-	const togglePopup = () => setIsOpenMenuPopup((prev) => !prev)
+  // 게임이 끝났다고 가정하고 ping 승리로 이동
+  useEffect(() => {
+    const timeout = setTimeout(() => {
+      const winnerId = 2; // Ping이 이겼다고 가정
+      navigate("/SoloMatch", { state: { winnerId } });
+    }, 3000);
 
-	return (
-		<Container>
-			<button onClick={togglePopup} className="absolute right-[30px] top-[30px]">
-				<img src={MenuButton} className="cursor-pointer opacity-60 hover:opacity-100 transition-opacity duration-300"/>
-			</button>
-			<Score />
-			<Field />
-			<AnimatePresence>
-				{isOpenMenuPopup && (
-					<>
-						<motion.div 
-							className="fixed inset-0 bg-black opacity-50"
-							initial={{ opacity: 0 }}
-							animate={{ opacity: 0.5 }}
-							exit={{ opacity: 0 }}
-						/>
-						<motion.div 
-							className="fixed inset-0 flex justify-center items-center"
-							initial={{ opacity: 0, scale: 0.8 }}
-							animate={{ opacity: 1, scale: 1 }}
-							exit={{ opacity: 0, scale: 0.8 }}
-							transition={{ duration: 0.3, ease: "easeInOut" }}
-						>
-							<MenuPopup onClose={togglePopup}/>
-						</motion.div>
-					</>
-				)}
-			</AnimatePresence>
-		</Container>
-	)
-}
+    return () => clearTimeout(timeout);
+  }, [navigate]);
 
-export default GameScreen
+  const togglePopup = () => setIsOpenMenuPopup((prev) => !prev);
+
+  return (
+    <Container>
+      <button
+        onClick={togglePopup}
+        className="absolute right-[30px] top-[30px]"
+      >
+        <img
+          src={MenuButton}
+          className="cursor-pointer opacity-60 hover:opacity-100 transition-opacity duration-300"
+        />
+      </button>
+      <Score />
+      <Field />
+      <AnimatePresence>
+        {isOpenMenuPopup && (
+          <>
+            <motion.div
+              className="fixed inset-0 bg-black opacity-50"
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 0.5 }}
+              exit={{ opacity: 0 }}
+            />
+            <motion.div
+              className="fixed inset-0 flex justify-center items-center"
+              initial={{ opacity: 0, scale: 0.8 }}
+              animate={{ opacity: 1, scale: 1 }}
+              exit={{ opacity: 0, scale: 0.8 }}
+              transition={{ duration: 0.3, ease: "easeInOut" }}
+            >
+              <MenuPopup onClose={togglePopup} />
+            </motion.div>
+          </>
+        )}
+      </AnimatePresence>
+    </Container>
+  );
+};
+
+export default GameScreen;

--- a/Frontend/src/pages/SoloMatch/SoloMatch.tsx
+++ b/Frontend/src/pages/SoloMatch/SoloMatch.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useLocation } from "react-router-dom";
 import { toast } from "react-toastify";
 import { CustomToastContainer, ToastStyle } from "../../styles/toastStyles";
 
@@ -19,8 +19,19 @@ const SoloMatch = () => {
   const [readyStates, setReadyStates] = useState<{ [userId: number]: boolean }>(
     {}
   );
+  const [winnerId, setWinnerId] = useState<number | null>(null);
   const toastShownRef = useRef(false);
+
   const navigate = useNavigate();
+  const location = useLocation();
+
+  useEffect(() => {
+    const stateWinnerId = location.state?.winnerId;
+    if (typeof stateWinnerId === "number") {
+      setWinnerId(stateWinnerId);
+      window.history.replaceState({}, document.title);
+    }
+  }, [location.state]);
 
   const handleReceiveReady = (userId: number) => {
     setReadyStates((prev) => ({
@@ -31,8 +42,6 @@ const SoloMatch = () => {
 
   const handleReadyClick = () => {
     handleReceiveReady(mockUsers.pong.id);
-
-    // 2초 후 Ping도 Ready
     setTimeout(() => {
       handleReceiveReady(mockUsers.ping.id);
     }, 2000);
@@ -64,6 +73,7 @@ const SoloMatch = () => {
           rightUser={mockUsers.ping}
           readyStates={readyStates}
           size={90}
+          winnerId={winnerId}
         />
       </OverlayWrapper>
       <Tournament onReadyClick={handleReadyClick} titleText="1 vs 1" />

--- a/Frontend/src/pages/SoloMatch/components/SoloMatchGrid/index.tsx
+++ b/Frontend/src/pages/SoloMatch/components/SoloMatchGrid/index.tsx
@@ -8,6 +8,7 @@ interface Props {
   rightUser: any;
   readyStates: { [userId: number]: boolean };
   size?: number;
+  winnerId?: number | null;
 }
 
 const SoloMatchGrid = ({
@@ -15,18 +16,21 @@ const SoloMatchGrid = ({
   rightUser,
   readyStates,
   size = 70,
+  winnerId,
 }: Props) => {
   return (
     <GridWrapper>
       <UserProfileCard
         user={leftUser}
         isReady={readyStates[leftUser.id]}
+        isWinner={leftUser.id === winnerId}
         size={size}
       />
       <VsText />
       <UserProfileCard
         user={rightUser}
         isReady={readyStates[rightUser.id]}
+        isWinner={rightUser.id === winnerId}
         size={size}
       />
     </GridWrapper>


### PR DESCRIPTION
## 🔗 반영 브랜치
ex. (#40) yeeun/SoloMatchWinner

## 📝 작업 내용
- `/SoloMatch` 페이지 진입 시 `WINNER` 텍스트가 항상 표시되는 문제 수정
- `GameScreen` → `SoloMatch`로 돌아올 때만 승자 표시되도록 로직 분리
    - `location.state.winnerId`가 존재할 때만 `winnerId` 상태로 설정
    - `window.history.replaceState()`로 상태 초기화하여 새로고침 시 승자 텍스트가 다시 표시되지 않도록 처리

### 📸 스크린샷 (선택)
- 게임 진행 전 `/SoloMatch`
<img width="1193" alt="스크린샷 2025-04-01 오후 3 38 33" src="https://github.com/user-attachments/assets/a6f31f23-4f27-41e4-b7a4-2dbfe0c27189" />

- `GameScreen` → `SoloMatch` 복귀 시
<img width="1195" alt="스크린샷 2025-04-01 오후 3 38 58" src="https://github.com/user-attachments/assets/d2a5597b-dda6-4b9f-97ca-2a06c13ecd51" />
