### PR TITLE
feat: 카운트다운, 듀스 알림, 우승자 알림 팝업 추가

### DIFF
--- a/Frontend/src/pages/Game/GameScreen.tsx
+++ b/Frontend/src/pages/Game/GameScreen.tsx
@@ -5,26 +5,15 @@ import GameCanvas from "./components/GameCanvas"
 import BallBullet from "../../assets/image/BallBullet.svg"
 
 const GameScreen = () => {
-	// const navigate = useNavigate();
-
-	// 게임이 끝났다고 가정하고 ping 승리로 이동
-	// useEffect(() => {
-	//   const timeout = setTimeout(() => {
-	//     const winnerId = 2; // Ping이 이겼다고 가정
-	//     navigate("/SoloMatch", { state: { winnerId } })
-	//   }, 3000)
-
-	//   return () => clearTimeout(timeout);
-	// }, [navigate])
 	return (
 		<Container>
-			<div className="absolute right-[10px] top-[18px] z-30">
+			<div className="absolute left-[334px] top-[18px] z-40">
 				<Giveup/>
 			</div>
-			<div className="absolute right-[278px] top-[100px] z-20">
+			<div className="absolute right-[238px] top-[120px] z-30">
 				<Score/>
 			</div>
-			<div className="absolute top-[155px] z-10">
+			<div className="absolute top-[162px] z-20">
 				<GameCanvas ballImg={BallBullet}/>
 			</div>
 		</Container>

--- a/Frontend/src/pages/Game/components/Animation.tsx
+++ b/Frontend/src/pages/Game/components/Animation.tsx
@@ -1,0 +1,23 @@
+import { motion } from "framer-motion"
+import { ReactNode } from "react"
+
+export const FadeOverlay = () => (
+	<motion.div
+		className="fixed inset-0 bg-black opacity-50"
+		initial={{ opacity: 0 }}
+		animate={{ opacity: 0.5 }}
+		exit={{ opacity: 0 }}
+	/>
+)
+
+export const PopupWrapper = ({ children }: { children: ReactNode }) => (
+	<motion.div
+		className="fixed inset-0 flex justify-center items-center"
+		initial={{ opacity: 0, scale: 0.8 }}
+		animate={{ opacity: 1, scale: 1 }}
+		exit={{ opacity: 0, scale: 0.8 }}
+		transition={{ duration: 0.3, ease: "easeInOut" }}
+	>
+		{children}
+	</motion.div>
+)

--- a/Frontend/src/pages/Game/components/GameCanvas.tsx
+++ b/Frontend/src/pages/Game/components/GameCanvas.tsx
@@ -1,24 +1,40 @@
-import { useEffect, useRef } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import Field from './Field'
 import Paddle from './Paddle'
 
 const GameCanvas = ({ ballImg }: { ballImg: string }) => {
 	const canvasRef = useRef<HTMLCanvasElement>(null)
 	const animationFrameId = useRef<number | null>(null)
-	// 성능저하 막기 위해 useState 대신 useRef 사용
 	const leftPaddle = useRef({ x: 6, y: 30 })
-	const rightPaddle = useRef({ x: 789, y: 275})
+	const rightPaddle = useRef({ x: 789, y: 275 })
+	const pressedKey = useRef<{ [key: string]: boolean }>({})
 	const paddleSpeed = 5
-	const pressedKey = useRef<{ [key:string]: boolean }>({})
-	// 키 입력 이벤트 처리
+	const BALL_WIDTH = 40
+	const BALL_HEIGHT = 20
+	const [ballX, setBallX] = useState(800 / 2 - BALL_WIDTH / 2)
+	const [ballY, setBallY] = useState(430 / 2 - BALL_HEIGHT / 2)	
+
+	const [countdown, setCountdown] = useState(3)
+	const [gameStarted, setGameStarted] = useState(false)
+	const [showStartText, setShowStartText] = useState(false)
+	
+	const ballImageRef = useRef<HTMLImageElement | null>(null)
+
+	// 캔버스와 컨텍스트 가져오기
+	const getCanvasAndContext = () => {
+		const canvas = canvasRef.current
+		const ctx = canvas?.getContext("2d")
+		return { canvas, ctx }
+	}
+
+	// 키 입력 처리
 	useEffect(() => {
-		const handleKeyDown = (event: KeyboardEvent) => {
-			pressedKey.current[event.key] = true
+		const handleKeyDown = (e: KeyboardEvent) => {
+			pressedKey.current[e.key] = true
 		}
-		const handleKeyUp = (event: KeyboardEvent) => {
-			pressedKey.current[event.key] = false
+		const handleKeyUp = (e: KeyboardEvent) => {
+			pressedKey.current[e.key] = false
 		}
-		
 		window.addEventListener("keydown", handleKeyDown)
 		window.addEventListener("keyup", handleKeyUp)
 
@@ -27,41 +43,107 @@ const GameCanvas = ({ ballImg }: { ballImg: string }) => {
 			window.removeEventListener("keyup", handleKeyUp)
 		}
 	}, [])
-	// 게임 업데이트 + 캔버스 렌더링
+
+	// 카운트다운 로직
 	useEffect(() => {
-		const canvas = canvasRef.current
-		if (!canvas) return
-		const ctx = canvas.getContext("2d")
-		if (!ctx) return
+		let timer: ReturnType<typeof setTimeout>
+		if (countdown > 0) {
+			timer = setTimeout(() => setCountdown((prev) => prev - 1), 1000)
+		} else if (countdown === 0) {
+			setShowStartText(true)
+			timer = setTimeout(() => {
+				setShowStartText(false)
+				setGameStarted(true)
+			}, 1000)
+		}
+		return () => clearTimeout(timer)
+	}, [countdown])
+
+	// 공 이미지 로딩
+  useEffect(() => {
+    const img = new Image()
+    img.src = ballImg
+    img.onload = () => {
+      ballImageRef.current = img
+    }
+  }, [ballImg])
+
+	// 게임 루프
+	useEffect(() => {
+		if (!gameStarted) return
+		const { canvas, ctx } = getCanvasAndContext()
+		if (!canvas || !ctx) return
 
 		const updatePaddles = () => {
-			if (pressedKey.current["w"]) leftPaddle.current.y = Math.max(leftPaddle.current.y - paddleSpeed, 0);
-      if (pressedKey.current["s"]) leftPaddle.current.y = Math.min(leftPaddle.current.y + paddleSpeed, 350);
-      if (pressedKey.current["ArrowUp"]) rightPaddle.current.y = Math.max(rightPaddle.current.y - paddleSpeed, 0);
-      if (pressedKey.current["ArrowDown"]) rightPaddle.current.y = Math.min(rightPaddle.current.y + paddleSpeed, 350);
+			if (pressedKey.current["w"]) leftPaddle.current.y = Math.max(leftPaddle.current.y - paddleSpeed, 0)
+			if (pressedKey.current["s"]) leftPaddle.current.y = Math.min(leftPaddle.current.y + paddleSpeed, 350)
+			if (pressedKey.current["ArrowUp"]) rightPaddle.current.y = Math.max(rightPaddle.current.y - paddleSpeed, 0)
+			if (pressedKey.current["ArrowDown"]) rightPaddle.current.y = Math.min(rightPaddle.current.y + paddleSpeed, 350)
 		}
 
 		const draw = () => {
+      ctx.clearRect(0, 0, canvas.width, canvas.height)
+      Field(ctx)
+      updatePaddles()
+      Paddle({ ctx, x: leftPaddle.current.x, y: leftPaddle.current.y })
+      Paddle({ ctx, x: rightPaddle.current.x, y: rightPaddle.current.y })
+
+      // 공 그리기
+      const ballImgEl = ballImageRef.current
+			if (ballImgEl) {
+				ctx.imageSmoothingEnabled = true
+				ctx.drawImage(ballImgEl, ballX, ballY, BALL_WIDTH, BALL_HEIGHT)
+			}
+			
+
+      animationFrameId.current = requestAnimationFrame(draw)
+    }
+
+    draw()
+    return () => {
+      if (animationFrameId.current) cancelAnimationFrame(animationFrameId.current)
+    }
+  }, [gameStarted, ballX, ballY])
+
+	// 카운트다운 및 텍스트 렌더링
+	useEffect(() => {
+		const { canvas, ctx } = getCanvasAndContext()
+		if (!canvas || !ctx) return
+	
+		const draw = () => {
 			ctx.clearRect(0, 0, canvas.width, canvas.height)
 			Field(ctx)
-
-			updatePaddles()
-
-			Paddle({ ctx, x: leftPaddle.current.x, y: leftPaddle.current.y})
-			Paddle({ ctx, x: rightPaddle.current.x, y: rightPaddle.current.y})
-
-			animationFrameId.current = requestAnimationFrame(draw)
+			Paddle({ ctx, x: leftPaddle.current.x, y: leftPaddle.current.y })
+			Paddle({ ctx, x: rightPaddle.current.x, y: rightPaddle.current.y })
+	
+			if (countdown > 0 || showStartText) {
+				ctx.fillStyle = "rgba(0, 0, 0, 0.5)"
+				ctx.fillRect(0, 0, canvas.width, canvas.height)
+	
+				ctx.fillStyle = "white"
+				ctx.font = "40px Sixtyfour"
+				ctx.textAlign = "center"
+				ctx.textBaseline = "middle"
+				ctx.fillText(
+					showStartText ? "Start!" : countdown.toString(),
+					canvas.width / 2,
+					canvas.height / 2
+				)
+			}
 		}
-
-		draw()
-
-		return () => {
-			if (animationFrameId.current) cancelAnimationFrame(animationFrameId.current)
-		}
-	}, [])
+	
+		const timer = setTimeout(draw, 50) // 50~100ms 지연
+	
+		return () => clearTimeout(timer)
+	}, [countdown, showStartText])
 
 	return (
-		<canvas ref={canvasRef} width={800} height={430} className="border-4 border-white"/>
+		<canvas
+			ref={canvasRef}
+			width={800}
+			height={430}
+			className="border-4 border-white"
+		/>
 	)
 }
 

--- a/Frontend/src/pages/Game/components/GameOverPopup.tsx
+++ b/Frontend/src/pages/Game/components/GameOverPopup.tsx
@@ -1,0 +1,32 @@
+import { useEffect } from "react"
+import { useNavigate } from "react-router-dom"
+
+interface GameOverPopupProps {
+	isPlayerWinner: boolean
+}
+
+const GameOverPopup: React.FC<GameOverPopupProps> = ({ isPlayerWinner }) => {
+	const navigate = useNavigate()
+
+	useEffect(() => {
+		const timeout = setTimeout(() => {
+			navigate("/SoloMatch", { state: { winner: isPlayerWinner ? "player" : "opponent" } })
+		}, 5000)
+
+		return () => clearTimeout(timeout)
+	}, [navigate, isPlayerWinner])
+
+	return (
+		<div className="bg-black w-[630px] h-[161px] flex items-center justify-center rounded-xl shadow-xl">
+			<p className="font-['Sixtyfour'] text-white text-xl text-center leading-[50px]">
+				<span className={isPlayerWinner ? "text-green-400" : "text-red-400"}>
+					{isPlayerWinner ? "You" : "Opponent"}
+				</span> won the game!
+				<br />
+				Back to the lobby in 5 sec!
+			</p>
+		</div>
+	)
+}
+
+export default GameOverPopup

--- a/Frontend/src/pages/Game/components/Giveup.tsx
+++ b/Frontend/src/pages/Game/components/Giveup.tsx
@@ -1,7 +1,8 @@
 import { useState } from "react"
-import { motion, AnimatePresence } from "framer-motion"
+import { AnimatePresence } from "framer-motion"
 import GiveupButtonOn from '../../../assets/image/GiveupButtonOn.png'
 import GiveupPopup from "./GiveupPopup"
+import { FadeOverlay, PopupWrapper } from "./Animation"
 
 const Giveup = () => {
 	const [isOpenPopup, setIsOpenPopup] = useState(false)
@@ -24,21 +25,10 @@ const Giveup = () => {
 			<AnimatePresence>
 				{isOpenPopup && (
 					<>
-						<motion.div 
-							className="fixed inset-0 bg-black opacity-50"
-							initial={{ opacity: 0 }}
-							animate={{ opacity: 0.5 }}
-							exit={{ opacity: 0 }}
-						/>
-						<motion.div 
-							className="fixed inset-0 flex justify-center items-center"
-							initial={{ opacity: 0, scale: 0.8 }}
-							animate={{ opacity: 1, scale: 1 }}
-							exit={{ opacity: 0, scale: 0.8 }}
-							transition={{ duration: 0.3, ease: "easeInOut" }}
-						>
-							<GiveupPopup onClose={togglePopup}/>
-						</motion.div>
+							<FadeOverlay/>
+							<PopupWrapper>
+								<GiveupPopup onClose={togglePopup}/>
+							</PopupWrapper>
 					</>
 				)}
 			</AnimatePresence>

--- a/Frontend/src/pages/Game/components/Score.tsx
+++ b/Frontend/src/pages/Game/components/Score.tsx
@@ -1,12 +1,66 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
+import { AnimatePresence } from "framer-motion"
+import GameOverPopup from './GameOverPopup'
+import { FadeOverlay, PopupWrapper } from './Animation'
 
 const Score = () => {
   const [playerScore, setPlayerScore] = useState(0);
   const [opponentScore, setOpponentScore] = useState(0); 
+	const [isGameOver, setIsGameOver] = useState(false)
+	const [winnerId, setWinnerId] = useState<number | null>(null)
+	const [isDeuce, setIsDeuce] = useState(false)
 
+	// 임시 유저 데이터
+	const playerId = 1
+	const opponentId = 2
+
+	// 점수 차이에 따라 우승 팝업, 듀스 알림 띄우기
+	useEffect(() => {
+		const diff = Math.abs(playerScore - opponentScore)
+	
+		if ((playerScore >= 11 || opponentScore >= 11) && diff >= 2) {
+			setIsGameOver(true)
+			setWinnerId(playerScore > opponentScore ? playerId : opponentId)
+			setIsDeuce(false)
+		} else if ((playerScore >= 10 && opponentScore >= 10) && diff === 1) {
+			setIsDeuce(true)
+		} else {
+			setIsDeuce(false)
+		}
+	}, [playerScore, opponentScore])
+	
   return (
-    <div className="font-['Sixtyfour'] font-[15px] text-white">
-      <span>You {playerScore} : {opponentScore} NAME</span>
+    <div className="font-['Sixtyfour'] font-[15px] relative">
+			{/* 듀스 메세지 */}
+			{isDeuce && (
+				<div className="text-yellow-400 absolute bottom-[30px] left-[95px]">
+					Deuce!
+				</div>
+			)}
+			{/* 점수판 */}
+			<div className="text-white w-[300px] text-center">
+				You {String(playerScore).padStart(3, '0')} : {String(opponentScore).padStart(3, '0')} NAME
+			</div>
+			{/* 팝업 메세지 */}
+			<div className="relative z-50">
+				<AnimatePresence>
+					{isGameOver && winnerId != null && (
+						<>
+							<div className="fixed inset-0">
+								<FadeOverlay/>
+								<PopupWrapper>
+									<GameOverPopup isPlayerWinner={winnerId === playerId}/>
+								</PopupWrapper>
+							</div>
+						</>
+					)}
+				</AnimatePresence>
+			</div>
+			{/* 테스트용 점수 증가 버튼(삭제 예정) */}
+			<div className="fixed bottom-6 right-6 flex gap-4 z-10">
+				<button onClick={() => setPlayerScore(s => s + 1)} className="bg-blue-600 px-4 py-2 rounded">+1 Player</button>
+				<button onClick={() => setOpponentScore(s => s + 1)} className="bg-red-600 px-4 py-2 rounded">+1 Opponent</button>
+			</div>
     </div>
   )
 }

--- a/Frontend/src/pages/Login/components/ActionButton.tsx
+++ b/Frontend/src/pages/Login/components/ActionButton.tsx
@@ -15,10 +15,10 @@ const ActionButton = ({ email, password, setError}: {
 	const handleButtonClick = (type: 'signIn' | 'signUp') => {
 		if (type === 'signIn') {
 			if (!email || !password) {
-				setError("이메일 또는 비밀번호를 입력해주세요.")
+				setError("Please enter your email or password.")
 				return
 			} else if (email !== mockUser.email || password !== mockUser.password) {
-				setError("아이디 또는 비밀번호가 일치하지 않습니다.")
+				setError("The email or password does not match.")
 			} else {
 				setError("")
 				navigate('/Home')


### PR DESCRIPTION
## 🔗 반영 브랜치
(#47) hyehan/GameScreenPageToReceiveData -> dev

## 📝 작업 내용
1. 카운트다운
[Screencast from 04-07-25 19:52:24.webm](https://github.com/user-attachments/assets/1ae0f027-8822-4453-b12c-80137a7ae699)

- 3, 2, 1하면 게임 화면 작동 활성화

2. 듀스 알림
![Screenshot from 2025-04-07 19-52-41](https://github.com/user-attachments/assets/589d68aa-6b62-4e13-8a71-60f2a25ed3c3)

- 11점을 앞두고 1점차이가 날 때마다 듀스 화면이 점수판 위에 뜸
- Give up 버튼 구석에 있어서 잘 안 보이는 것 같아서 점수판 위에 둬 시야에 더 잘 보이게 고려함

3. 우승자 알림 팝업
![Screenshot from 2025-04-07 19-52-51](https://github.com/user-attachments/assets/13c01e52-e458-49ad-9e3f-b999cbb21a35)
![Screenshot from 2025-04-07 19-53-00](https://github.com/user-attachments/assets/6b2d449e-6fad-4024-b6b9-7f67a04f3039)

- 본인이 우승하면 You, 상대가 우승하면 Opponent로 우승자를 알려주는 팝업이 뜸
- 5초가 지나면 자동으로 대기화면으로 이동하도록 수정

- 맨 밑의 두 개는 테스트용 버튼

4. 이전 피알에서 지적 받았던 로그인 실패 알람 문구 수정
- 한글말고 영어로 수정했습니다.

## 💬 리뷰 요구사항

현재 토너먼트 게임 화면과 일대일 게임 화면이 분리되어 있지 않아 추후에 분리할 예정
페이지 구현부터 빠르게 해야 한다고 생각해서 코드 예쁘게 정리하기 보단 일단 빠르게 기능 구현부터 진행합니다.
테스트가 필요해서 속성값을 받아오는 상태로 짜지 않고 일단 제대로 작동하고 화면에 잘 출력되는지 확인하기 위해 임시로 작동하게 코드를 구현했습니다. 추후 회의 이후에 관련 질문 후 수정하겠습니다.
그래도 수정사항 보이면 알려주세요.