### PR TITLE
feat: 구글 관련 로그인 옵션 추가

### DIFF
--- a/Frontend/src/pages/Login/Login.tsx
+++ b/Frontend/src/pages/Login/Login.tsx
@@ -1,14 +1,11 @@
 import { useState } from "react"
 import Container from "./components/Container"
 import MainTitle from "./components/MainTitle"
-import InputField from "./components/InputField"
-import ActionButton from "./components/ActionButton"
 import Credit from "./components/Credit"
+import ActionButton from "./components/ActionButton"
 import ErrorMessage from "./components/ErrorMessage"
 
 const Login = () => {
-	const [email, setEmail] = useState("")
-	const [password, setPassword] = useState("")
 	const [error, setError] = useState("")
 
 	return (
@@ -19,24 +16,8 @@ const Login = () => {
 			<div className="absolute left-1/2 -translate-x-1/2 top-[10px]">
 				<ErrorMessage message={error} setError={setError}/>
 			</div>
-			<div className="flex flex-col items-center justify-center space-y-[26px] absolute left-[200px] top-[270px]">
-				<InputField
-					label="EMAIL"
-					value={email}
-					onChange={(e) => setEmail(e.target.value)}
-					type="text"
-					width="250px"
-				/>
-				<InputField
-					label="PW"
-					value={password}
-					onChange={(e) => setPassword(e.target.value)}
-					type="password"
-					width="250px"
-				/>
-			</div>
-			<div className="absolute left-1/2 -translate-x-1/2 top-[370px]">
-				<ActionButton email={email} password={password} setError={setError}/>
+			<div className="absolute left-1/2 -translate-x-1/2 top-[320px]">
+			<ActionButton setError={setError}/>
 			</div>
 			<div className="absolute left-1/2 -translate-x-1/2 w-[630px] bottom-[35px]">
 				<Credit />

--- a/Frontend/src/pages/Login/components/ActionButton.tsx
+++ b/Frontend/src/pages/Login/components/ActionButton.tsx
@@ -1,41 +1,67 @@
-import { useState } from "react"
-import { useNavigate } from "react-router-dom"
-import useLogin from "./useLogin"
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import SelectHighlight from "../../../assets/image/SelectHighlight.svg"
+import InputField from './InputField'
+import useLogin from './useLogin'
 
 interface ActionButtonProps {
-	email: string
-	password: string
 	setError: (message: string) => void
 }
 
-const ActionButton = ({ email, password, setError }: ActionButtonProps) => {
+const ActionButton = ({ setError }: ActionButtonProps) => {
 	const navigate = useNavigate()
-	const [mode, setMode] = useState<"default" | "signupOptions">("default")
+	const [mode, setMode] = useState<"default" | "signInOptions" | "signUpOptions" | "signInWithEmail">("default")
+	const [email, setEmail] = useState("")
+	const [password, setPassword] = useState("")
+
 	const login = useLogin(setError)
-
-	const handleButtonClick = (action: "signIn" | "signUp") => {
-		if (action === "signIn") {
-			login(email, password)
-		} else {
-			setMode("signupOptions")
-		}
-	}
-
-	const handleGoogleSignup = () => {
-		navigate('/RegisterWithGoogle') // 임시(수정하려면 수정해도 됩니다)
-	}
-
-	const handleLocalSignup = () => {
-		navigate('/RegisterWithEmail')
-	}
 
 	const buttonClass = "cursor-pointer flex gap-[10px] -ml-[40px] group justify-center items-center"
 	const imgClass = "opacity-0 group-hover:opacity-100 transition-opacity duration-500"
 	const textClass = "text-white font-['QuinqueFive'] text-[15px]"
 
-	return (
-		<div className="flex flex-col space-y-[10px]">
+	const handleButtonClick = (action: "signIn" | "signUp") => {
+		if (action === "signIn") {
+			setMode("signInOptions")
+		} else {
+			setMode("signUpOptions")
+		}
+	}
+
+	const handleSignInWithEmail = () => {
+		login(email, password)
+	}
+
+	const renderOptions = () => (
+		<div className="flex flex-col items-center gap-[12px] mt-[-25px]">
+			<button className={buttonClass}>
+				<img src={SelectHighlight} alt="highlight" className={imgClass} />
+				<span className={textClass}>CONTINUE WITH GOOGLE</span>
+			</button>
+
+			<button className={buttonClass} onClick={handleEmailClick}>
+				<img src={SelectHighlight} alt="highlight" className={imgClass} />
+				<span className={textClass}>CONTINUE WITH EMAIL</span>
+			</button>
+
+			<button className={buttonClass} onClick={() => setMode("default")}>
+				<img src={SelectHighlight} alt="highlight" className={imgClass} />
+				<span className={textClass}>GO BACK</span>
+			</button>
+  </div>
+	)
+
+	const handleEmailClick = () => {
+		if (mode === "signInOptions") {
+			setMode("signInWithEmail")
+		} else {
+			navigate('/RegisterWithEmail')
+		}
+	}
+
+
+  return (
+    <div className="flex flex-col items-center gap-4 p-6">
 			{mode === "default" && (
 				<>
 					{["signIn", "signUp"].map((action) => (
@@ -44,7 +70,11 @@ const ActionButton = ({ email, password, setError }: ActionButtonProps) => {
 							onClick={() => handleButtonClick(action as "signIn" | "signUp")}
 							className={buttonClass}
 						>
-							<img src={SelectHighlight} alt="highlight" className={imgClass} />
+							<img 
+								src={SelectHighlight}
+								alt="SelectHighlight"
+								className={imgClass}
+							/>
 							<span className={textClass}>
 								{action === "signIn" ? "SIGN IN" : "SIGN UP"}
 							</span>
@@ -53,26 +83,38 @@ const ActionButton = ({ email, password, setError }: ActionButtonProps) => {
 				</>
 			)}
 
-			{mode === "signupOptions" && (
-				<>
-					<button onClick={handleGoogleSignup} className={buttonClass}>
-						<img src={SelectHighlight} alt="highlight" className={imgClass} />
-						<span className={textClass}>CONTINUE WITH GOOGLE</span>
-					</button>
-
-					<button onClick={handleLocalSignup} className={buttonClass}>
-						<img src={SelectHighlight} alt="highlight" className={imgClass} />
-						<span className={textClass}>SIGN UP WITH EMAIL</span>
-					</button>
-
-					<button onClick={() => setMode("default")} className={buttonClass}>
-						<img src={SelectHighlight} alt="highlight" className={imgClass} />
-						<span className={textClass}>GO BACK</span>
-					</button>
-				</>
-			)}
+		{(mode === "signInOptions" || mode === "signUpOptions") && renderOptions()}
+    
+		{mode === "signInWithEmail" && (
+			<div className="flex flex-col items-center justify-center space-y-[26px] absolute -top-[30px]">
+			<InputField
+				label="EMAIL"
+				value={email}
+				onChange={(e) => setEmail(e.target.value)}
+				type="text"
+				width="250px"
+			/>
+			<InputField
+				label="PW"
+				value={password}
+				onChange={(e) => setPassword(e.target.value)}
+				type="password"
+				width="250px"
+			/>
+			<div className="space-y-4">
+				<button className={buttonClass} onClick={handleSignInWithEmail}>
+					<img src={SelectHighlight} alt="highlight" className={imgClass} />
+					<span className={textClass}>CONFIRM</span>
+				</button>
+				<button className={buttonClass} onClick={() => setMode("signInOptions")}>
+					<img src={SelectHighlight} alt="highlight" className={imgClass} />
+					<span className={textClass}>GO BACK</span>
+				</button>
+			</div>
+			</div>
+		)}
 		</div>
-	)
+  );
 }
 
 export default ActionButton

--- a/Frontend/src/pages/Login/components/MainTitle.tsx
+++ b/Frontend/src/pages/Login/components/MainTitle.tsx
@@ -1,7 +1,7 @@
 const MainTitle = () => {
 	return (
 		<div className="w-[416px]">
-			<p className="ColorC96565 font-['SuperPixel'] text-[60px] text-center leading-[75px]">
+			<p className="ColorC96565 font-['SuperPixel'] text-[60px] text-center leading-[72px]">
 				PING PONG<br/>
 				GANG
 			</p>

--- a/Frontend/src/pages/Register/components/MainTitle.tsx
+++ b/Frontend/src/pages/Register/components/MainTitle.tsx
@@ -1,7 +1,7 @@
 const MainTitle = () => {
 	return (
 		<div className="w-[416px]">
-			<p className="ColorC96565 font-['SuperPixel'] text-[60px] text-center leading-[75px]">
+			<p className="ColorC96565 font-['SuperPixel'] text-[60px] text-center leading-[72px]">
 				PING PONG<br/>
 				GANG
 			</p>


### PR DESCRIPTION
## 🔗 반영 브랜치
(#59) hyehan/LoginGooglebutton -> dev

## 📝 작업 내용
1. 구글 연동 로그인 영역 추가
![Screenshot from 2025-04-13 17-36-37](https://github.com/user-attachments/assets/b28566c1-1c40-47b5-b1d2-ba5834a25062)

- 맨 처음 접속하면 바로 뜨던 로그인 영역 삭제
- sign in, sign up 둘 중 하나를 선택해야만 로그인 or 회원 가입 진행
- 각 버튼으로 들어가면 구글 연동 관련인지 자체 회원 관련인지 선택지 뜨고 선택할 수 있게 변경
- 자체 회원 로그인으로 들어가야만 자체 회원 로그인이 가능해지도록 수정
- 자체 회원가입으로 들어가야만 자체 회원 가입이 가능해지도록 수정
