### PR TITLE
fix:친구 요청 승인, 거절 시 빈 body 보내도록 수정, body key명 수정

### DIFF
--- a/Frontend/src/pages/FriendList/components/AddFriendPopup.tsx
+++ b/Frontend/src/pages/FriendList/components/AddFriendPopup.tsx
@@ -27,7 +27,7 @@ const AddFriendPopup: React.FC<AddFriendPopupProps> = ({ onClose }) => {
 
     const fetchUsers = async () => {
       try {
-        // ?status=NONE&exceptMe=1
+        // ?status=NONE&exceptMe=true (본인 검색 결과에서 빠짐, 서로 아무 이벤트가 일어나지 않은 유저 목록)
         const params = new URLSearchParams({
           status: "NONE",
           exceptMe: "true"

--- a/Frontend/src/pages/FriendList/components/AlarmPopup.tsx
+++ b/Frontend/src/pages/FriendList/components/AlarmPopup.tsx
@@ -85,7 +85,8 @@ const AlarmPopup = ({ onClose, onFriendAccepted }: AlarmPopupProps) => {
   const handleRejectRequest = async (friendId: string) => {
     try {
       const response = await authFetch(`${import.meta.env.VITE_API_URL}/api/v1/friends/requests/${friendId}/reject`, {
-        method: 'PATCH'
+        method: 'PATCH',
+        body: '{}'
       })
 
       if (!response) return

--- a/Frontend/src/pages/FriendList/components/ContactList.tsx
+++ b/Frontend/src/pages/FriendList/components/ContactList.tsx
@@ -38,18 +38,21 @@ const ContactList = ({ searchTerm , refreshTrigger }: ContactListProps) => {
 
         const result = await response.json()
 
-      if (response.ok && result.data?.friends) {
-        console.log("✅ Import friend list successful.")
-        setContacts(result.data.friends)
-      } else {
-        toast.error(result.message || "Failed to load friend list.", {
-          position: "top-center",
-          autoClose: 2000,
-          style: {
-            width: "350px",
-            textAlign: "center"
-          }
-        })
+        if (response.ok && result.data?.friends) {
+          setContacts(result.data.friends)
+          console.log("✅ Import friend list successful.")
+        } else {
+          toast.error(result.message || "Failed to load friend list.", {
+            position: "top-center",
+            autoClose: 2000,
+            style: {
+              width: "350px",
+              textAlign: "center"
+            }
+          })
+        }
+      } catch (error) {
+        console.error("🚨 Unexpected error occurred: ", error)
       }
 
     }

--- a/Frontend/src/pages/FriendList/components/ContactList.tsx
+++ b/Frontend/src/pages/FriendList/components/ContactList.tsx
@@ -20,6 +20,8 @@ interface ContactListProps {
 const ContactList = ({ searchTerm , refreshTrigger }: ContactListProps) => {
 	const [contacts, setContacts] = useState<Contact[]>([])
 
+  // 처음 mount 되면 무조건 한 번 실행 됨 -> 최초 렌더링 Ok
+  // 이후 부터는 친구 승인 될 때마다 친구 목록 업데이트
   useEffect(() => {
     const fetchFriends = async () => {
       try {
@@ -74,7 +76,6 @@ const ContactList = ({ searchTerm , refreshTrigger }: ContactListProps) => {
 							alt={contact.nickname}
 							className="w-[65px] h-[65px] rounded-full"
 						/>
-
 						<div className="flex items-center w-[150px] justify-between">
 							<span className="text-[20px]">{contact.nickname}</span>
 							<LinkState status={contact.status} />

--- a/Frontend/src/pages/FriendList/components/SearchResultCard.tsx
+++ b/Frontend/src/pages/FriendList/components/SearchResultCard.tsx
@@ -25,7 +25,7 @@ const SearchResultCard = ({ user }: { user: User }) => {
           'Content-Type': 'application/json'
         },
         body: JSON.stringify({
-          targetId: user.id
+          friendId: user.id
         })
       })
 

--- a/Frontend/src/utils/authFetch.ts
+++ b/Frontend/src/utils/authFetch.ts
@@ -18,7 +18,7 @@ const authFetch = async (url: string, options: RequestInit = {}): Promise<Respon
     // JSON 요청일 때만 Content-Type 명시
     // body가 FormData가 아니라면 일반적인 JSON 요청이라 Content-type을 직접 명시해줘야 함
     // FormData는 절대 명시 X 브라우저가 자동 생성
-    if (!isFormData && options.body !== undefined) { // GET일 때 Content-Type 붙이기 않기
+    if (!isFormData && options.body !== undefined) { // body가 없을 때 Content-Type 붙이기 않기
       baseHeaders["Content-Type"] = 'application/json'
     }
 

--- a/Frontend/src/utils/authFetch.ts
+++ b/Frontend/src/utils/authFetch.ts
@@ -18,7 +18,7 @@ const authFetch = async (url: string, options: RequestInit = {}): Promise<Respon
     // JSON 요청일 때만 Content-Type 명시
     // body가 FormData가 아니라면 일반적인 JSON 요청이라 Content-type을 직접 명시해줘야 함
     // FormData는 절대 명시 X 브라우저가 자동 생성
-    if (!isFormData) {
+    if (!isFormData && options.method !== 'GET') { // GET일 때 Content-Type 붙이기 않기
       baseHeaders["Content-Type"] = 'application/json'
     }
 
@@ -57,10 +57,14 @@ const authFetch = async (url: string, options: RequestInit = {}): Promise<Respon
 
       // HttpOnly 쿠키는 js에서 직접 삭제 불가능 -> 서버에 삭제 요청
       // 쿠키에 refresh token이 남아 있기만 하면 삭제 가능
-      await fetch(`${import.meta.env.VITE_API_URL}/api/v1/auth/logout`, {
+      try {
+        await fetch(`${import.meta.env.VITE_API_URL}/api/v1/auth/logout`, {
         method: 'GET',
-        credentials: "include", // 쿠키 포함 (refreshToken 전송)
-      })
+          credentials: "include", // 쿠키 포함 (refreshToken 전송)
+        })
+      } catch(error) {
+        console.log("⚠️ Logout request failed: ", error)
+      }
       
       setTimeout(() => {
         toast.dismiss(toastId)

--- a/Frontend/src/utils/authFetch.ts
+++ b/Frontend/src/utils/authFetch.ts
@@ -18,7 +18,7 @@ const authFetch = async (url: string, options: RequestInit = {}): Promise<Respon
     // JSON 요청일 때만 Content-Type 명시
     // body가 FormData가 아니라면 일반적인 JSON 요청이라 Content-type을 직접 명시해줘야 함
     // FormData는 절대 명시 X 브라우저가 자동 생성
-    if (!isFormData && options.method !== 'GET') { // GET일 때 Content-Type 붙이기 않기
+    if (!isFormData && options.body !== undefined) { // GET일 때 Content-Type 붙이기 않기
       baseHeaders["Content-Type"] = 'application/json'
     }
 


### PR DESCRIPTION
## 🔗 반영 브랜치
hyehan/FriendListPageSocket -> dev

## 📝 작업 내용
1. 친구 승인, 거절 시 PATCH와 빈 body 보내도록 수정
2. 친구 목록 API 요청 시 키 값 잘못 보내고 있던 것 수정: targetId -> friendId
3. authFetch에서 body가 없이 들어왔을 경우 Content-Type 붙이지 않도록 수정