### PR TITLE
chore(config): `vercel.json`의 api 리다이렉트 규칙 수정

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,10 @@
 {
   "rewrites": [
     {
+      "source": "/api/(.*)",
+      "destination": "https://217.142.135.254/api/v1/$1"
+    },
+    {
       "source": "/(.*)",
       "destination": "/"
     }


### PR DESCRIPTION
## 🔗 반영 브랜치

`ci/vercel-api/config → dev`

## 📝 작업 내용

배포 주소에서 API 요청이 작동하지 않는 문제를 해결하기 위해 `vercel.json` 설정을 업데이트 합니다.