### PR TITLE
feat: 로그인 페이지 디자인 구현

### DIFF
--- a/src/pages/SignInPage/EmailLoginPage/index.tsx
+++ b/src/pages/SignInPage/EmailLoginPage/index.tsx
@@ -10,10 +10,9 @@ import * as styles from './styles.css';
 
 export const EmailSignInPage = () => {
   const navigate = useNavigate();
-  const [email, setEmail] = useState<string>('');
-  const [password, setPassword] = useState<string>('');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
   const { setToken } = useAuthAtom();
-
   const { mutateAsync } = useLogin();
 
   const handleSelect = async (index: number) => {
@@ -36,16 +35,31 @@ export const EmailSignInPage = () => {
     <Flex direction="column" justifyContent="space-between" style={{ height: '100%' }}>
       <Branding className={styles.branding} />
 
-      {/* TODO: Implement UI */}
       <Flex direction="column" justifyContent="center">
-        <Flex justifyContent="center" style={{ color: 'white' }}>
-          <p>EMAIL : </p>
-          <input value={email} onChange={(e) => setEmail(e.target.value)} />
-        </Flex>
-        <Flex justifyContent="center" style={{ color: 'white' }}>
-          <p>PW : </p>
-          <input value={password} onChange={(e) => setPassword(e.target.value)} type="password" />
-        </Flex>
+        <div className={styles.inputRow}>
+          <label htmlFor="email" className={styles.label}>
+            EMAIL :
+          </label>
+          <input
+            id="email"
+            className={styles.input}
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+          />
+        </div>
+
+        <div className={styles.inputRow}>
+          <label htmlFor="password" className={styles.label}>
+            PW :
+          </label>
+          <input
+            id="password"
+            className={styles.input}
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+          />
+        </div>
 
         <DefaultStepNavigator
           style={{ marginTop: '12px' }}

--- a/src/pages/SignInPage/EmailLoginPage/styles.css.ts
+++ b/src/pages/SignInPage/EmailLoginPage/styles.css.ts
@@ -1,11 +1,38 @@
 import { style } from '@vanilla-extract/css';
 
-import { rem, theme } from '@/styles';
+import { rem } from '@/styles';
 
 export const branding = style({
-  marginTop: theme.size.brandingTopMargin,
+  marginTop: rem(60),
 });
 
 export const license = style({
   marginBottom: rem(36),
+});
+
+export const label = style({
+  display: 'inline-block',
+  letterSpacing: rem(1),
+  width: rem(100),
+  textAlign: 'right',
+});
+
+export const inputRow = style({
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+  marginBottom: rem(12),
+  color: 'white',
+  fontSize: rem(24),
+  textTransform: 'uppercase',
+});
+
+export const input = style({
+  background: 'none',
+  border: 'none',
+  borderBottom: 'none',
+  color: 'white',
+  outline: 'none',
+  width: rem(200),
+  padding: `${rem(4)} ${rem(8)}`,
 });


### PR DESCRIPTION
## 🔗 반영 브랜치
- closed #110
- `yeeun/signin-ui → dev`

## 📝 작업 내용
- 로그인 페이지 Figma 디자인에 맞춰 UI 구현
- 회원가입 페이지와 동일하게 rem 단위로 일관성 있게 변환

### 📸 스크린샷 (선택)
<img width="872" alt="스크린샷 2025-05-12 오전 10 24 11" src="https://github.com/user-attachments/assets/57cef572-0872-4f5a-a9e6-f360d1b180da" />

## 💬 리뷰 요구사항(선택)
- 회원가입 페이지와의 스타일 일관성을 고려해 rem 단위로 작업했는데, 혹시 기준이 다르거나 수정할 부분 있다면 피드백 부탁드립니다.