### PR TITLE
ci(vercel): 배포 API 주소 변경

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
   "rewrites": [
     {
       "source": "/api/(.*)",
-      "destination": "https://217.142.135.254/api/v1/$1"
+      "destination": "https://217.142.135.254/api/$1"
     },
     {
       "source": "/(.*)",


### PR DESCRIPTION
## 🔗 반영 브랜치

`ci/vercel-api-destination → dev`

## 📝 작업 내용

[미리보기 페이지](https://pingpong-gang-dev.vercel.app/)에서 변경된 API 프록시 주소로 인해 API 요청이 되지 않던 오류를 수정합니다.