### PR TITLE
refactor: 공통 BackButton 컴포넌트 사용

### DIFF
--- a/src/pages/SignUpPage/index.tsx
+++ b/src/pages/SignUpPage/index.tsx
@@ -19,6 +19,10 @@ export const SignUpPage = () => {
 
   const navigate = useNavigate();
 
+  const handleBack = () => {
+    navigate(-1);
+  };
+
   const handleMailVerify = () => {
     if (!email) {
       alert('Please enter your email');
@@ -64,6 +68,7 @@ export const SignUpPage = () => {
 
   return (
     <Flex direction="column" justifyContent="space-between" style={{ height: '100%' }}>
+      <button className={styles.backButton} onClick={handleBack} />
       <Branding className={styles.branding} />
 
       <form className={styles.form} onSubmit={handleSubmit}>

--- a/src/pages/SignUpPage/index.tsx
+++ b/src/pages/SignUpPage/index.tsx
@@ -4,6 +4,7 @@ import { useNavigate } from 'react-router-dom';
 import { useMailVerification, useRegister } from '@/api';
 import { Flex } from '@/components/system';
 import { Branding } from '@/components/ui';
+import { BackButton } from '@/components/ui/back-button';
 
 import * as styles from './styles.css';
 
@@ -18,10 +19,6 @@ export const SignUpPage = () => {
   const { mutateAsync: registerMutation } = useRegister();
 
   const navigate = useNavigate();
-
-  const handleBack = () => {
-    navigate(-1);
-  };
 
   const handleMailVerify = () => {
     if (!email) {
@@ -68,7 +65,7 @@ export const SignUpPage = () => {
 
   return (
     <Flex direction="column" justifyContent="space-between" style={{ height: '100%' }}>
-      <button className={styles.backButton} onClick={handleBack} />
+      <BackButton />
       <Branding className={styles.branding} />
 
       <form className={styles.form} onSubmit={handleSubmit}>

--- a/src/pages/SignUpPage/styles.css.ts
+++ b/src/pages/SignUpPage/styles.css.ts
@@ -89,3 +89,12 @@ export const submitButton = style({
     opacity: 0.7,
   },
 });
+
+export const backButton = style({
+  position: 'absolute',
+  top: rem(12),
+  left: rem(12),
+  width: rem(30),
+  height: rem(30),
+  background: `url('/assets/images/back-button.svg') center / contain no-repeat`,
+});

--- a/src/pages/SignUpPage/styles.css.ts
+++ b/src/pages/SignUpPage/styles.css.ts
@@ -89,12 +89,3 @@ export const submitButton = style({
     opacity: 0.7,
   },
 });
-
-export const backButton = style({
-  position: 'absolute',
-  top: rem(12),
-  left: rem(12),
-  width: rem(30),
-  height: rem(30),
-  background: `url('/assets/images/back-button.svg') center / contain no-repeat`,
-});


### PR DESCRIPTION
## 🔗 반영 브랜치
feature/signup-ui-enhancement -> dev

## 📝 작업 내용
회원가입 페이지에 뒤로가기 버튼 추가하였습니다.

## 💬 리뷰 요구사항(선택)
현재 뒤로가기 버튼(src/components/ui/back-button)은 항상 `PATH.HOME`으로 이동하도록 구현되어 있는데, 이전 페이지로 이동하는 방식(`navigate(-1)`)으로 하는 건 어떨까요?

토너먼트에서는 "직전 페이지"로의 이동이 더 자연스러운 경우도 있을 것 같아 제안드립니다. 의견 부탁드립니다!