### PR TITLE
style: toast 메세지 디자인 변경, 프로필 닉네임 글자 수 제한

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -121,7 +121,14 @@ const App = () => {
       element: (
         <QueryClientProvider>
           <Outlet />
-          <Toaster position="top-right" />
+          <Toaster
+            position="top-right"
+            toastOptions={{
+              classNames: {
+                toast: 'pixel-toast',
+              },
+            }}
+          />
         </QueryClientProvider>
       ),
       children: [...publicRoutes, ...privateRoutes],

--- a/src/pages/ProfilePage/components/nickname-edit-dialog/index.tsx
+++ b/src/pages/ProfilePage/components/nickname-edit-dialog/index.tsx
@@ -45,7 +45,8 @@ export const NicknameEditDialog = ({ children }: PropsWithChildren) => {
         <input
           className={styles.input}
           type="text"
-          placeholder="Maximum of 10 characters allowed"
+          placeholder="Max 8 letters!"
+          maxLength={8}
           value={nickname}
           onChange={(e) => setNickname(e.target.value)}
         />

--- a/src/styles/global.css.ts
+++ b/src/styles/global.css.ts
@@ -51,3 +51,13 @@ globalStyle('*::-webkit-scrollbar-thumb', {
 globalStyle('*::-webkit-scrollbar-track', {
   backgroundColor: 'transparent',
 });
+
+globalStyle('.pixel-toast', {
+  fontFamily: 'DungGeunMo',
+  color: 'black !important',
+  fontSize: '17px !important',
+  backgroundColor: 'white !important',
+  border: '2px solid black !important',
+  borderRadius: '4px !important',
+  boxShadow: '0 4px 0 black !important',
+});


### PR DESCRIPTION
## 🔗 반영 브랜치
(#160) feature/toastDesign -> dev

## 📝 작업 내용
1. 토스트 디자인 변경
2. 프로필 placeholder 짤리는 것 같아서 문구 변경 및 8글자로 제한되도록 코드 수정


### 📸 스크린샷
![Screenshot from 2025-05-19 19-03-18](https://github.com/user-attachments/assets/25c9ac40-aa94-428e-8405-91eeb878a838)
![Screenshot from 2025-05-19 19-13-13](https://github.com/user-attachments/assets/3d14e7ee-e3cd-4de6-a4b6-90b952acb592)

## 💬 리뷰 요구사항
토스트 디자인 이대로 괜찮을지 확인 부탁드립니다!
