### PR TITLE
fix(step-navigator): 컴포넌트가 포커스된 경우에만 탭과 키보드 전환이 가능하도록 수정

### DIFF
--- a/src/components/ui/step-navigator/hooks/useNavigation.ts
+++ b/src/components/ui/step-navigator/hooks/useNavigation.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback } from 'react';
+import { useEffect, useState, useCallback, useRef } from 'react';
 
 type NavigationState = {
   selected: number;
@@ -10,6 +10,8 @@ type NavigationActions = {
   onSelect: (index: number) => void;
   onHover: (index: number | null) => void;
   onFocus: (index: number | null) => void;
+  onContainerFocus: () => void;
+  onContainerBlur: () => void;
 };
 
 type UseNavigationProps = {
@@ -20,6 +22,7 @@ type UseNavigationProps = {
 
 export const useNavigation = ({ items, onSelect, initial = 0 }: UseNavigationProps) => {
   const validInitial = items.length > 0 ? Math.min(Math.max(0, initial), items.length - 1) : 0;
+  const isFocused = useRef(false);
 
   const [state, setState] = useState<NavigationState>({
     selected: validInitial,
@@ -31,7 +34,7 @@ export const useNavigation = ({ items, onSelect, initial = 0 }: UseNavigationPro
 
   const handleKeyDown = useCallback(
     (e: KeyboardEvent) => {
-      if (items.length === 0) return;
+      if (items.length === 0 || !isFocused.current) return;
 
       if (e.key === 'ArrowUp' || e.key === 'ArrowLeft') {
         e.preventDefault();
@@ -84,6 +87,12 @@ export const useNavigation = ({ items, onSelect, initial = 0 }: UseNavigationPro
     },
     onFocus: (index: number | null) => {
       setState((prev) => ({ ...prev, focused: index }));
+    },
+    onContainerFocus: () => {
+      isFocused.current = true;
+    },
+    onContainerBlur: () => {
+      isFocused.current = false;
     },
   };
 

--- a/src/components/ui/step-navigator/index.tsx
+++ b/src/components/ui/step-navigator/index.tsx
@@ -17,7 +17,11 @@ type StepNavigatorProps = {
     onBlur: () => void;
     onClick: () => void;
   }) => ReactNode;
-  renderContainer: (props: { children: ReactNode }) => ReactNode;
+  renderContainer: (props: {
+    children: ReactNode;
+    onFocus: () => void;
+    onBlur: () => void;
+  }) => ReactNode;
 };
 
 const StepNavigator = ({
@@ -47,7 +51,11 @@ const StepNavigator = ({
     }),
   );
 
-  return renderContainer({ children: itemsList });
+  return renderContainer({
+    children: itemsList,
+    onFocus: actions.onContainerFocus,
+    onBlur: actions.onContainerBlur,
+  });
 };
 
 export { StepNavigator };

--- a/src/components/ui/step-navigator/variants/default-step-navigator/index.tsx
+++ b/src/components/ui/step-navigator/variants/default-step-navigator/index.tsx
@@ -22,11 +22,14 @@ export const DefaultStepNavigator = ({
       items={items}
       onSelect={onSelect}
       initial={initial}
-      renderContainer={({ children }) => (
+      renderContainer={({ children, onFocus, onBlur }) => (
         <nav
           className={styles.navigation}
           aria-label="단계 네비게이터"
           role="navigation"
+          onFocus={onFocus}
+          onBlur={onBlur}
+          tabIndex={0}
           {...props}
         >
           <ul className={styles.list} role="list">

--- a/src/pages/FriendPage/components/friend-search-dialog/index.tsx
+++ b/src/pages/FriendPage/components/friend-search-dialog/index.tsx
@@ -22,7 +22,7 @@ export const FriendSearchDialog = ({ children }: PropsWithChildren) => {
   const { data } = useUsersSearch({
     nickname,
     exceptMe: true,
-    status: 'NONE',
+    status: ['NONE'],
   });
 
   const debouncedNickname = useDebounce((value: string) => {

--- a/src/pages/FriendPage/components/friend-search-dialog/index.tsx
+++ b/src/pages/FriendPage/components/friend-search-dialog/index.tsx
@@ -22,7 +22,7 @@ export const FriendSearchDialog = ({ children }: PropsWithChildren) => {
   const { data } = useUsersSearch({
     nickname,
     exceptMe: true,
-    status: ['NONE'],
+    status: 'NONE',
   });
 
   const debouncedNickname = useDebounce((value: string) => {

--- a/src/pages/GamePage/GameSelectPage/index.tsx
+++ b/src/pages/GamePage/GameSelectPage/index.tsx
@@ -65,7 +65,11 @@ export const GameSelectPage = () => {
               {text}
             </button>
           )}
-          renderContainer={({ children }) => <div className={styles.buttonWrapper}>{children}</div>}
+          renderContainer={({ children, onFocus, onBlur }) => (
+            <div className={styles.buttonWrapper} onFocus={onFocus} onBlur={onBlur} tabIndex={0}>
+              {children}
+            </div>
+          )}
         />
       )}
 
@@ -94,7 +98,11 @@ export const GameSelectPage = () => {
               onBlur={onBlur}
             />
           )}
-          renderContainer={({ children }) => <div className={styles.modeWrapper}>{children}</div>}
+          renderContainer={({ children, onFocus, onBlur }) => (
+            <div className={styles.modeWrapper} onFocus={onFocus} onBlur={onBlur} tabIndex={0}>
+              {children}
+            </div>
+          )}
         />
       )}
 

--- a/src/pages/HomePage/index.tsx
+++ b/src/pages/HomePage/index.tsx
@@ -23,6 +23,7 @@ export const HomePage = () => {
         <DefaultStepNavigator
           items={['START GAME', 'HISTORY', 'FRIEND', 'PROFILE']}
           onSelect={handleSelect}
+          style={{ outline: 'none' }}
         />
         <GameLicense className={styles.license} />
       </Flex>

--- a/src/pages/LandingPage/index.tsx
+++ b/src/pages/LandingPage/index.tsx
@@ -25,7 +25,11 @@ export const LandingPage = () => {
   return (
     <Flex direction="column" justifyContent="space-between" style={{ height: '100%' }}>
       <Branding className={styles.branding} />
-      <DefaultStepNavigator items={['SIGN IN', 'SIGN UP']} onSelect={handleSelect} />
+      <DefaultStepNavigator
+        items={['SIGN IN', 'SIGN UP']}
+        onSelect={handleSelect}
+        style={{ outline: 'none' }}
+      />
       <GameLicense className={styles.license} />
     </Flex>
   );

--- a/src/pages/SignInPage/EmailLoginPage/index.tsx
+++ b/src/pages/SignInPage/EmailLoginPage/index.tsx
@@ -62,7 +62,7 @@ export const EmailSignInPage = () => {
         </div>
 
         <DefaultStepNavigator
-          style={{ marginTop: '12px' }}
+          style={{ marginTop: '12px', outline: 'none' }}
           items={['CONTINUE', 'GO BACK']}
           onSelect={handleSelect}
         />

--- a/src/pages/SignInPage/index.tsx
+++ b/src/pages/SignInPage/index.tsx
@@ -33,6 +33,7 @@ export const SignInPage = () => {
       <DefaultStepNavigator
         items={['CONTINUE WITH GOOGLE', 'CONTINUE WITH EMAIL', 'GO BACK']}
         onSelect={handleSelect}
+        style={{ outline: 'none' }}
       />
 
       <GameLicense className={styles.license} />


### PR DESCRIPTION
## 🔗 반영 브랜치

- resolved #166 
- `fix/step-navigator-focus → dev`

## 📝 작업 내용

`step-navigator` 컴포넌트를 사용하는 페이지에서 `window` 전역에 거쳐 포커스가 잡히는 오류를 수정했습니다.