### PR TITLE
feat: 친구 block/unblock API 요청 구현

### DIFF
--- a/src/api/mutations/useBlockFriend.ts
+++ b/src/api/mutations/useBlockFriend.ts
@@ -1,5 +1,4 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { toast } from 'sonner';
 
 import { fetcher } from '@/api';
 import { queryKeys } from '@/api/queryKey';
@@ -17,10 +16,7 @@ export const useBlockFriend = () => {
 
   return useMutation({
     mutationFn: patchBlockFriend,
-    onSuccess: async (response) => {
-      toast.success(response.message, {
-        position: 'top-left',
-      });
+    onSuccess: async () => {
       await queryClient.invalidateQueries(queryKeys.friendsMe());
     },
   });

--- a/src/api/mutations/useBlockFriend.ts
+++ b/src/api/mutations/useBlockFriend.ts
@@ -18,7 +18,9 @@ export const useBlockFriend = () => {
   return useMutation({
     mutationFn: patchBlockFriend,
     onSuccess: async (response) => {
-      toast.success(response.message);
+      toast.success(response.message, {
+        position: 'top-left',
+      });
       await queryClient.invalidateQueries(queryKeys.friendsMe());
     },
   });

--- a/src/api/mutations/useBlockFriend.ts
+++ b/src/api/mutations/useBlockFriend.ts
@@ -1,0 +1,25 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+
+import { fetcher } from '@/api';
+import { queryKeys } from '@/api/queryKey';
+import { HttpResponse } from '@/api/types';
+
+type Request = {
+  friendId: number;
+};
+
+const patchBlockFriend = (payload: Request) =>
+  fetcher.patch<HttpResponse>(`v1/friends/${payload.friendId}/block`, { json: {} });
+
+export const useBlockFriend = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: patchBlockFriend,
+    onSuccess: async (response) => {
+      toast.success(response.message);
+      await queryClient.invalidateQueries(queryKeys.friendsMe());
+    },
+  });
+};

--- a/src/api/mutations/useUnblockFriend.ts
+++ b/src/api/mutations/useUnblockFriend.ts
@@ -1,0 +1,25 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+
+import { fetcher } from '@/api';
+import { queryKeys } from '@/api/queryKey';
+import { HttpResponse } from '@/api/types';
+
+type Request = {
+  friendId: number;
+};
+
+const patchUnblockFriend = (payload: Request) =>
+  fetcher.patch<HttpResponse>(`v1/friends/${payload.friendId}/unblock`, { json: {} });
+
+export const useUnblockFriend = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: patchUnblockFriend,
+    onSuccess: async (response) => {
+      toast.success(response.message);
+      await queryClient.invalidateQueries(queryKeys.friendsMe());
+    },
+  });
+};

--- a/src/api/mutations/useUnblockFriend.ts
+++ b/src/api/mutations/useUnblockFriend.ts
@@ -18,7 +18,9 @@ export const useUnblockFriend = () => {
   return useMutation({
     mutationFn: patchUnblockFriend,
     onSuccess: async (response) => {
-      toast.success(response.message);
+      toast.success(response.message, {
+        position: 'top-left',
+      });
       await queryClient.invalidateQueries(queryKeys.friendsMe());
     },
   });

--- a/src/api/mutations/useUnblockFriend.ts
+++ b/src/api/mutations/useUnblockFriend.ts
@@ -1,5 +1,4 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { toast } from 'sonner';
 
 import { fetcher } from '@/api';
 import { queryKeys } from '@/api/queryKey';
@@ -17,10 +16,7 @@ export const useUnblockFriend = () => {
 
   return useMutation({
     mutationFn: patchUnblockFriend,
-    onSuccess: async (response) => {
-      toast.success(response.message, {
-        position: 'top-left',
-      });
+    onSuccess: async () => {
       await queryClient.invalidateQueries(queryKeys.friendsMe());
     },
   });

--- a/src/api/queries/useTournamentHistory.ts
+++ b/src/api/queries/useTournamentHistory.ts
@@ -1,8 +1,7 @@
 import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
 
 import { queryKeys } from '@/api/queryKey';
-
-import { TournamentRoundType } from '../types';
+import { TournamentRoundType } from '@/api/types/game';
 
 export const useTournamentHistory = (type: TournamentRoundType) =>
   useQuery(queryKeys.tournamentHistory(type));

--- a/src/components/ui/back-button/index.tsx
+++ b/src/components/ui/back-button/index.tsx
@@ -4,11 +4,15 @@ import { PATH } from '@/constants';
 
 import * as styles from './styles.css';
 
-export const BackButton = () => {
+type BackButtonProps = {
+  toPath?: string;
+};
+
+export const BackButton = ({ toPath }: BackButtonProps) => {
   const navigate = useNavigate();
 
   const handleClick = () => {
-    navigate(PATH.HOME);
+    navigate(toPath ?? PATH.HOME);
   };
 
   return <button className={styles.button} onClick={handleClick} aria-label="Go to home page" />;

--- a/src/pages/FriendPage/ChatRoomPage/components/chat-friend-header/index.tsx
+++ b/src/pages/FriendPage/ChatRoomPage/components/chat-friend-header/index.tsx
@@ -1,3 +1,5 @@
+import { toast } from 'sonner';
+
 import { useBlockFriend } from '@/api/mutations/useBlockFriend';
 import { useUnblockFriend } from '@/api/mutations/useUnblockFriend';
 import { Friend } from '@/api/types';
@@ -18,9 +20,31 @@ export const FriendHeader = ({ friend }: FriendHeaderProps) => {
     const payload = { friendId: friend.friendId };
 
     if (isBlocked) {
-      unblockFriend(payload);
+      unblockFriend(payload, {
+        onSuccess: (response) => {
+          toast.success(response.message, {
+            position: 'top-left',
+          });
+        },
+        onError: () => {
+          toast.error('차단 해제에 실패했습니다.', {
+            position: 'top-left',
+          });
+        },
+      });
     } else {
-      blockFriend(payload);
+      blockFriend(payload, {
+        onSuccess: (response) => {
+          toast.success(response.message, {
+            position: 'top-left',
+          });
+        },
+        onError: () => {
+          toast.error('차단에 실패했습니다.', {
+            position: 'top-left',
+          });
+        },
+      });
     }
   };
 

--- a/src/pages/FriendPage/ChatRoomPage/components/chat-friend-header/index.tsx
+++ b/src/pages/FriendPage/ChatRoomPage/components/chat-friend-header/index.tsx
@@ -1,5 +1,5 @@
-import { useState } from 'react';
-
+import { useBlockFriend } from '@/api/mutations/useBlockFriend';
+import { useUnblockFriend } from '@/api/mutations/useUnblockFriend';
 import { Friend } from '@/api/types';
 
 import * as styles from './styles.css';
@@ -9,10 +9,19 @@ type FriendHeaderProps = {
 };
 
 export const FriendHeader = ({ friend }: FriendHeaderProps) => {
-  const [isBlocked, setIsBlocked] = useState(friend.status === 'BLOCKED');
+  const { mutate: blockFriend } = useBlockFriend();
+  const { mutate: unblockFriend } = useUnblockFriend();
+
+  const isBlocked = friend.status === 'BLOCKED';
 
   const handleToggleBlock = () => {
-    setIsBlocked((prev) => !prev);
+    const payload = { friendId: friend.friendId };
+
+    if (isBlocked) {
+      unblockFriend(payload);
+    } else {
+      blockFriend(payload);
+    }
   };
 
   return (

--- a/src/pages/FriendPage/ChatRoomPage/components/chat-friend-header/index.tsx
+++ b/src/pages/FriendPage/ChatRoomPage/components/chat-friend-header/index.tsx
@@ -22,27 +22,19 @@ export const FriendHeader = ({ friend }: FriendHeaderProps) => {
     if (isBlocked) {
       unblockFriend(payload, {
         onSuccess: (response) => {
-          toast.success(response.message, {
-            position: 'top-left',
-          });
+          toast.success(response.message);
         },
         onError: () => {
-          toast.error('차단 해제에 실패했습니다.', {
-            position: 'top-left',
-          });
+          toast.error('차단 해제에 실패했습니다.');
         },
       });
     } else {
       blockFriend(payload, {
         onSuccess: (response) => {
-          toast.success(response.message, {
-            position: 'top-left',
-          });
+          toast.success(response.message);
         },
         onError: () => {
-          toast.error('차단에 실패했습니다.', {
-            position: 'top-left',
-          });
+          toast.error('차단에 실패했습니다.');
         },
       });
     }
@@ -50,17 +42,18 @@ export const FriendHeader = ({ friend }: FriendHeaderProps) => {
 
   return (
     <div className={styles.header}>
+      <button className={styles.blockButton} data-selected={isBlocked} onClick={handleToggleBlock}>
+        <span className={styles.buttonText}>{isBlocked ? 'UNBLOCK' : 'BLOCK'}</span>
+      </button>
+
       <div className={styles.profile}>
+        <span className={styles.nickname}>{friend.nickname}</span>
         <img
           src={friend.avatarUrl || '/assets/images/sample-avatar.png'}
           alt="friend avatar"
           className={styles.avatar}
         />
-        <span className={styles.nickname}>{friend.nickname}</span>
       </div>
-      <button className={styles.blockButton} data-selected={isBlocked} onClick={handleToggleBlock}>
-        <span className={styles.buttonText}>{isBlocked ? 'UNBLOCK' : 'BLOCK'}</span>
-      </button>
     </div>
   );
 };

--- a/src/pages/FriendPage/ChatRoomPage/components/chat-friend-header/styles.css.ts
+++ b/src/pages/FriendPage/ChatRoomPage/components/chat-friend-header/styles.css.ts
@@ -6,7 +6,7 @@ export const header = style({
   display: 'flex',
   justifyContent: 'space-between',
   alignItems: 'center',
-  marginBottom: rem(12),
+  marginBottom: rem(15),
 });
 
 export const profile = style({
@@ -19,6 +19,7 @@ export const profile = style({
 export const avatar = style({
   width: rem(70),
   height: rem(70),
+  marginRight: rem(20),
   borderRadius: '50%',
   objectFit: 'cover',
   flexShrink: 0,
@@ -26,6 +27,7 @@ export const avatar = style({
 
 export const nickname = style({
   color: theme.color.white,
+  marginRight: rem(30),
   fontSize: rem(28),
   textTransform: 'uppercase',
   letterSpacing: rem(2),
@@ -36,6 +38,8 @@ export const blockButton = style({
   position: 'relative',
   width: rem(110),
   height: rem(40),
+  marginRight: rem(20),
+  marginTop: rem(30),
   color: theme.color.white,
   fontSize: rem(18),
   background: `url('/assets/images/base-button-normal.png') no-repeat center`,

--- a/src/pages/FriendPage/ChatRoomPage/components/chat-friend-list/index.tsx
+++ b/src/pages/FriendPage/ChatRoomPage/components/chat-friend-list/index.tsx
@@ -5,25 +5,29 @@ import { ProfileCard } from '@/components/ui';
 import * as styles from './styles.css';
 
 type FriendListProps = {
-  friend: Friend;
+  friends: Friend[];
 };
 
-export const FriendList = ({ friend }: FriendListProps) => {
+export const FriendList = ({ friends }: FriendListProps) => {
   const { status } = useStatusAtom();
-
-  const friendStatus = status.find((s) => s.friendId === friend.friendId)?.status;
 
   return (
     <div className={styles.friendList}>
       <ul className={styles.list}>
         <li className={styles.divider} />
-        <li className={styles.item}>
-          <ProfileCard
-            avatarUrl={friend.avatarUrl || '/assets/images/sample-avatar.png'}
-            nickname={friend.nickname}
-            status={friendStatus}
-          />
-        </li>
+        {friends.map((friend) => {
+          const friendStatus = status.find((s) => s.friendId === friend.friendId)?.status;
+
+          return (
+            <li key={friend.friendId} className={styles.item}>
+              <ProfileCard
+                avatarUrl={friend.avatarUrl || '/assets/images/sample-avatar.png'}
+                nickname={friend.nickname}
+                status={friendStatus}
+              />
+            </li>
+          );
+        })}
       </ul>
     </div>
   );

--- a/src/pages/FriendPage/ChatRoomPage/index.tsx
+++ b/src/pages/FriendPage/ChatRoomPage/index.tsx
@@ -19,23 +19,19 @@ export const ChatRoomPage = () => {
 
   return (
     <div className={styles.wrapper}>
-      <div className={styles.chatSection}>
-        {currentFriend && <FriendHeader friend={currentFriend} />}
-        <ChatBox />
-      </div>
-
       <div className={styles.sidebar}>
         <div className={styles.header}>
-          <button
-            className={styles.exitButton}
-            aria-label="채팅 나가기"
-            onClick={() => navigate(-1)}
-          />
+          <button className={styles.button} aria-label="채팅 나가기" onClick={() => navigate(-1)} />
         </div>
 
         <div className={styles.friendListWrapper}>
           {currentFriend && <FriendList friend={currentFriend} />}
         </div>
+      </div>
+
+      <div className={styles.chatSection}>
+        {currentFriend && <FriendHeader friend={currentFriend} />}
+        <ChatBox />
       </div>
     </div>
   );

--- a/src/pages/FriendPage/ChatRoomPage/index.tsx
+++ b/src/pages/FriendPage/ChatRoomPage/index.tsx
@@ -25,7 +25,7 @@ export const ChatRoomPage = () => {
         </div>
 
         <div className={styles.friendListWrapper}>
-          {currentFriend && <FriendList friend={currentFriend} />}
+          {currentFriend && <FriendList friends={friends} />}
         </div>
       </div>
 

--- a/src/pages/FriendPage/ChatRoomPage/index.tsx
+++ b/src/pages/FriendPage/ChatRoomPage/index.tsx
@@ -1,6 +1,8 @@
-import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router-dom';
 
 import { useFriendsMe } from '@/api';
+import { BackButton } from '@/components/ui';
+import { PATH } from '@/constants';
 
 import { ChatBox } from './components/chat-box';
 import { FriendHeader } from './components/chat-friend-header';
@@ -8,7 +10,6 @@ import { FriendList } from './components/chat-friend-list';
 import * as styles from './styles.css';
 
 export const ChatRoomPage = () => {
-  const navigate = useNavigate();
   const { data } = useFriendsMe();
   const friends = data?.data?.friends ?? [];
 
@@ -21,7 +22,7 @@ export const ChatRoomPage = () => {
     <div className={styles.wrapper}>
       <div className={styles.sidebar}>
         <div className={styles.header}>
-          <button className={styles.button} aria-label="채팅 나가기" onClick={() => navigate(-1)} />
+          <BackButton toPath={PATH.FRIEND} />
         </div>
 
         <div className={styles.friendListWrapper}>

--- a/src/pages/FriendPage/ChatRoomPage/styles.css.ts
+++ b/src/pages/FriendPage/ChatRoomPage/styles.css.ts
@@ -12,6 +12,19 @@ export const wrapper = style({
   overflow: 'hidden',
 });
 
+export const button = style({
+  position: 'absolute',
+  top: rem(5),
+  left: rem(5),
+  width: rem(32),
+  height: rem(32),
+  opacity: 0.6,
+  transition: 'opacity 200ms ease',
+  background: 'url("/assets/images/back-button.svg")',
+
+  ':hover': { opacity: 1 },
+});
+
 export const chatSection = style({
   display: 'flex',
   flexDirection: 'column',


### PR DESCRIPTION
## 🔗 반영 브랜치
(#173) feature/friendListblockAPI -> dev

## 📝 작업 내용
1. 친구 block/unblock API 요청 구현
2. 서버로부터 날아오는 response.message 토스트 메세지로 띄우기
3. DM창 스타일 수정
4. Backbutton에 toPath라는 Props를 추가하여 원하는 경로로 이동할 수 있도록 수정

### 📸 스크린샷
![Screenshot from 2025-05-23 14-42-49](https://github.com/user-attachments/assets/9b5340c6-858b-4e30-a969-1f8be33f7817)
![Screenshot from 2025-05-23 14-42-51](https://github.com/user-attachments/assets/898066ff-127a-41e8-aef2-6369d9c54481)
![Screenshot from 2025-05-23 14-42-56](https://github.com/user-attachments/assets/4343833b-611b-4522-95a2-afc8fb5acedf)

