### PR TITLE
feat: 프로필 페이지 닉네임 입력 부분 수정

### DIFF
--- a/src/pages/ProfilePage/components/nickname-edit-dialog/index.tsx
+++ b/src/pages/ProfilePage/components/nickname-edit-dialog/index.tsx
@@ -15,10 +15,15 @@ import * as styles from './styles.css';
 export const NicknameEditDialog = ({ children }: PropsWithChildren) => {
   const [isOpen, setIsOpen] = useState<boolean>(false);
   const [nickname, setNickname] = useState<string>('');
+  const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
 
   const { mutate: updateProfileMutation } = useUpdateProfile();
 
   const handleSubmit = () => {
+    if (isSubmitting) return;
+
+    setIsSubmitting(true);
+
     updateProfileMutation(
       { nickname },
       {
@@ -26,10 +31,12 @@ export const NicknameEditDialog = ({ children }: PropsWithChildren) => {
           toast.success('닉네임 변경 완료');
           setNickname('');
           setIsOpen(false);
+          setIsSubmitting(false);
         },
         onError: (error) => {
           console.error(error);
           toast.error('닉네임 변경 실패');
+          setIsSubmitting(false);
         },
       },
     );
@@ -52,11 +59,12 @@ export const NicknameEditDialog = ({ children }: PropsWithChildren) => {
           onKeyDown={(e) => {
             if (e.key === 'Enter') {
               e.preventDefault();
+              e.stopPropagation();
               handleSubmit();
             }
           }}
         />
-        <button className={styles.button} onClick={handleSubmit}>
+        <button type="button" className={styles.button} onClick={handleSubmit}>
           Confirm
         </button>
       </DialogContent>

--- a/src/pages/ProfilePage/components/nickname-edit-dialog/index.tsx
+++ b/src/pages/ProfilePage/components/nickname-edit-dialog/index.tsx
@@ -51,6 +51,7 @@ export const NicknameEditDialog = ({ children }: PropsWithChildren) => {
           onChange={(e) => setNickname(e.target.value)}
           onKeyDown={(e) => {
             if (e.key === 'Enter') {
+              e.preventDefault();
               handleSubmit();
             }
           }}

--- a/src/pages/ProfilePage/components/nickname-edit-dialog/index.tsx
+++ b/src/pages/ProfilePage/components/nickname-edit-dialog/index.tsx
@@ -47,6 +47,7 @@ export const NicknameEditDialog = ({ children }: PropsWithChildren) => {
           e.preventDefault();
           inputRef.current?.focus();
         }}
+        aria-describedby={undefined}
       >
         <DialogClose />
         <DialogTitle className={styles.title}>Change nickname</DialogTitle>

--- a/src/pages/ProfilePage/components/nickname-edit-dialog/index.tsx
+++ b/src/pages/ProfilePage/components/nickname-edit-dialog/index.tsx
@@ -1,4 +1,4 @@
-import { PropsWithChildren, useState, useRef, useEffect } from 'react';
+import { PropsWithChildren, useState, useRef } from 'react';
 import { toast } from 'sonner';
 
 import { useUpdateProfile } from '@/api';
@@ -15,15 +15,12 @@ import * as styles from './styles.css';
 export const NicknameEditDialog = ({ children }: PropsWithChildren) => {
   const [isOpen, setIsOpen] = useState<boolean>(false);
   const [nickname, setNickname] = useState<string>('');
-  const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
   const inputRef = useRef<HTMLInputElement>(null);
 
-  const { mutate: updateProfileMutation } = useUpdateProfile();
+  const { mutate: updateProfileMutation, isPending } = useUpdateProfile();
 
   const handleSubmit = () => {
-    if (isSubmitting) return;
-
-    setIsSubmitting(true);
+    if (isPending) return;
 
     updateProfileMutation(
       { nickname },
@@ -32,51 +29,47 @@ export const NicknameEditDialog = ({ children }: PropsWithChildren) => {
           toast.success('닉네임 변경 완료');
           setNickname('');
           setIsOpen(false);
-          setIsSubmitting(false);
         },
         onError: (error) => {
           console.error(error);
           toast.error('닉네임 변경 실패');
-          setIsSubmitting(false);
         },
       },
     );
   };
 
-  useEffect(() => {
-    if (isOpen) {
-      setTimeout(() => {
-        inputRef.current?.focus();
-      }, 0);
-    }
-  }, [isOpen]);
-
   return (
     <Dialog open={isOpen} onOpenChange={setIsOpen}>
       <DialogTrigger>{children}</DialogTrigger>
-      <DialogContent className={styles.content}>
+      <DialogContent
+        className={styles.content}
+        onOpenAutoFocus={(e) => {
+          e.preventDefault();
+          inputRef.current?.focus();
+        }}
+      >
         <DialogClose />
-
         <DialogTitle className={styles.title}>Change nickname</DialogTitle>
-        <input
-          ref={inputRef}
-          className={styles.input}
-          type="text"
-          placeholder="Max 8 letters!"
-          maxLength={8}
-          value={nickname}
-          onChange={(e) => setNickname(e.target.value)}
-          onKeyDown={(e) => {
-            if (e.key === 'Enter') {
-              e.preventDefault();
-              e.stopPropagation();
-              handleSubmit();
-            }
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            handleSubmit();
           }}
-        />
-        <button type="button" className={styles.button} onClick={handleSubmit}>
-          Confirm
-        </button>
+          style={{ display: 'contents' }}
+        >
+          <input
+            ref={inputRef}
+            className={styles.input}
+            type="text"
+            placeholder="Max 8 letters!"
+            maxLength={8}
+            value={nickname}
+            onChange={(e) => setNickname(e.target.value)}
+          />
+          <button type="submit" className={styles.button} disabled={isPending}>
+            Confirm
+          </button>
+        </form>
       </DialogContent>
     </Dialog>
   );

--- a/src/pages/ProfilePage/components/nickname-edit-dialog/index.tsx
+++ b/src/pages/ProfilePage/components/nickname-edit-dialog/index.tsx
@@ -49,6 +49,11 @@ export const NicknameEditDialog = ({ children }: PropsWithChildren) => {
           maxLength={8}
           value={nickname}
           onChange={(e) => setNickname(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') {
+              handleSubmit();
+            }
+          }}
         />
         <button className={styles.button} onClick={handleSubmit}>
           Confirm

--- a/src/pages/ProfilePage/components/nickname-edit-dialog/index.tsx
+++ b/src/pages/ProfilePage/components/nickname-edit-dialog/index.tsx
@@ -1,4 +1,4 @@
-import { PropsWithChildren, useState } from 'react';
+import { PropsWithChildren, useState, useRef, useEffect } from 'react';
 import { toast } from 'sonner';
 
 import { useUpdateProfile } from '@/api';
@@ -16,6 +16,7 @@ export const NicknameEditDialog = ({ children }: PropsWithChildren) => {
   const [isOpen, setIsOpen] = useState<boolean>(false);
   const [nickname, setNickname] = useState<string>('');
   const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
+  const inputRef = useRef<HTMLInputElement>(null);
 
   const { mutate: updateProfileMutation } = useUpdateProfile();
 
@@ -42,14 +43,23 @@ export const NicknameEditDialog = ({ children }: PropsWithChildren) => {
     );
   };
 
+  useEffect(() => {
+    if (isOpen) {
+      setTimeout(() => {
+        inputRef.current?.focus();
+      }, 0);
+    }
+  }, [isOpen]);
+
   return (
     <Dialog open={isOpen} onOpenChange={setIsOpen}>
       <DialogTrigger>{children}</DialogTrigger>
-      <DialogContent className={styles.content} aria-describedby={undefined}>
+      <DialogContent className={styles.content}>
         <DialogClose />
 
         <DialogTitle className={styles.title}>Change nickname</DialogTitle>
         <input
+          ref={inputRef}
           className={styles.input}
           type="text"
           placeholder="Max 8 letters!"


### PR DESCRIPTION
## 🔗 반영 브랜치
- closed #189 
- `feature/profile-enter-key-submit → dev`

## 📝 작업 내용
Profile 페이지 닉네임 입력창에서 Enter 키로도 닉네임 변경이 가능하도록 기능 추가

## 💬 리뷰 요구사항(선택)
.