### PR TITLE
fix(api): 리프레시 토큰 에러 핸들링 추가

### DIFF
--- a/src/api/fetcher.ts
+++ b/src/api/fetcher.ts
@@ -43,9 +43,10 @@ export const instance = ky.create({
             }
 
             const newToken = await refreshAccessToken();
+
             if (!newToken) {
               window.localStorage.removeItem(LOCAL_STORAGE.ACCESS_TOKEN);
-              return response;
+              throw new Error('Unable to refresh access token');
             }
 
             const retryHeaders = new Headers(options?.headers || {});

--- a/src/api/refreshAccessToken.ts
+++ b/src/api/refreshAccessToken.ts
@@ -7,20 +7,27 @@ interface Response {
   accessToken: string;
 }
 
-const postRefreshToken = async () => {
-  const response = await ky.post(`/api/v1/auth/refresh-token`, {
-    credentials: 'include',
-  });
-  return await response.json<HttpResponse<Response>>();
+const postRefreshToken = async (): Promise<HttpResponse<Response>> => {
+  return await ky
+    .post(`/api/v1/auth/refresh-token`, {
+      credentials: 'include',
+    })
+    .json();
 };
 
-export async function refreshAccessToken() {
-  const { data } = (await postRefreshToken()) ?? {};
-  const newAccessToken = data?.accessToken ?? undefined;
+export const refreshAccessToken = async (): Promise<string | undefined> => {
+  try {
+    const { data } = await postRefreshToken();
+    const newAccessToken = data?.accessToken ?? undefined;
 
-  if (newAccessToken) {
-    window.localStorage.setItem(LOCAL_STORAGE.ACCESS_TOKEN, newAccessToken);
+    if (newAccessToken) {
+      window.localStorage.setItem(LOCAL_STORAGE.ACCESS_TOKEN, newAccessToken);
+    }
+
+    return newAccessToken;
+  } catch (error) {
+    console.error('Failed to refresh access token:', error);
+    window.localStorage.removeItem(LOCAL_STORAGE.ACCESS_TOKEN);
+    throw new Error('Unable to refresh access token');
   }
-
-  return newAccessToken;
-}
+};


### PR DESCRIPTION
## 🔗 반영 브랜치

- fixed #194
- `fix/refresh-token → dev`

## 📝 작업 내용

- 리프레시 토큰 자체가 유효하지 않은 경우, 엑세스 토큰을 제거하는 로직을 추가했습니다.