### PR TITLE
feat(matching): 대기방(AUTO SOLO) 매칭 소켓 추가

### DIFF
--- a/src/pages/GameSelectPage/GameMatchingPage/AutoMatchingPage/Auto1vs1/index.tsx
+++ b/src/pages/GameSelectPage/GameMatchingPage/AutoMatchingPage/Auto1vs1/index.tsx
@@ -54,7 +54,7 @@ export const Auto1vs1 = () => {
       socket.off('waiting-room-update', handleWaitingRoomUpdate);
       socket.off('tournament-created', handleTournamentCreated);
     };
-  }, [searchParams, socket, users]);
+  }, [searchParams, socket]);
 
   const me = users.find((u) => u.id === uid);
   const opponent = users.find((u) => u.id !== uid);

--- a/src/pages/GameSelectPage/GameMatchingPage/AutoMatchingPage/Auto1vs1/index.tsx
+++ b/src/pages/GameSelectPage/GameMatchingPage/AutoMatchingPage/Auto1vs1/index.tsx
@@ -26,7 +26,6 @@ export const Auto1vs1 = () => {
   });
 
   const [searchParams] = useSearchParams();
-  const roomId = searchParams.get('roomId');
 
   const [users, setUsers] = useState<WaitingRoomPlayer[]>([]);
 
@@ -37,7 +36,7 @@ export const Auto1vs1 = () => {
     const size = _size ? Number(_size) : NaN;
 
     socket.emit('auto-join', { tournamentSize: size });
-  }, [roomId, searchParams, socket, socket.connected]);
+  }, [searchParams, socket, socket.connected]);
 
   useEffect(() => {
     const handleWaitingRoomUpdate = (data: WaitingRoomUpdateResponse) => {

--- a/src/pages/GameSelectPage/GameMatchingPage/AutoMatchingPage/Auto1vs1/index.tsx
+++ b/src/pages/GameSelectPage/GameMatchingPage/AutoMatchingPage/Auto1vs1/index.tsx
@@ -53,7 +53,7 @@ export const Auto1vs1 = () => {
       socket.off('waiting-room-update', handleWaitingRoomUpdate);
       socket.off('tournament-created', handleTournamentCreated);
     };
-  }, [searchParams, socket]);
+  }, [socket]);
 
   const me = users.find((u) => u.id === uid);
   const opponent = users.find((u) => u.id !== uid);

--- a/src/pages/GameSelectPage/GameMatchingPage/AutoMatchingPage/Auto1vs1/index.tsx
+++ b/src/pages/GameSelectPage/GameMatchingPage/AutoMatchingPage/Auto1vs1/index.tsx
@@ -1,9 +1,13 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 
-import { useUsersMe } from '@/api';
-import { useWaitingSocketStore } from '@/api/store/useWaitingSocketStore.ts';
-import { useWaitingStore } from '@/api/store/useWaitingStateStore.ts';
+import {
+  useUsersMe,
+  type TournamentCreatedResponse,
+  type WaitingRoomPlayer,
+  type WaitingRoomUpdateResponse,
+} from '@/api';
+import { useSocket } from '@/api/socket';
 import { Flex } from '@/components/system';
 import { BackButton } from '@/components/ui';
 
@@ -13,32 +17,49 @@ import { WaitingMessage } from '../../_components/waiting-message';
 
 export const Auto1vs1 = () => {
   const { data } = useUsersMe();
-  const meId = data?.data?.id;
+  const uid = data?.data?.id;
 
-  const { socket } = useWaitingSocketStore();
+  const { socket } = useSocket({
+    path: 'waiting',
+    handshake: '/ws/main-game',
+    withToken: true,
+  });
+
   const [searchParams] = useSearchParams();
+  const roomId = searchParams.get('roomId');
 
-  const { users, tournamentSize, setTournamentSize } = useWaitingStore();
-
-  useEffect(() => {
-    const size = searchParams.get('size');
-    if (size) {
-      const parsed = Number(size);
-      if (!isNaN(parsed)) {
-        setTournamentSize(parsed);
-      }
-    }
-  }, [searchParams, setTournamentSize]);
+  const [users, setUsers] = useState<WaitingRoomPlayer[]>([]);
 
   useEffect(() => {
-    if (!socket || !socket.connected || tournamentSize === 0) return;
-    socket.emit('auto-join', { tournamentSize });
-  }, [socket, tournamentSize]);
+    if (!socket.connected) return;
 
-  const me = users.find((u) => u.id === meId);
-  const opponent = users.find((u) => u.id !== meId);
+    const _size = searchParams.get('size');
+    const size = _size ? Number(_size) : NaN;
 
-  const isMeFirst = users[0]?.id === meId || !opponent;
+    socket.emit('auto-join', { tournamentSize: size });
+  }, [roomId, searchParams, socket, socket.connected]);
+
+  useEffect(() => {
+    const handleWaitingRoomUpdate = (data: WaitingRoomUpdateResponse) => {
+      setUsers(data.users);
+    };
+
+    const handleTournamentCreated = (data: TournamentCreatedResponse) => {
+      alert(`Tournament created with ID: ${data.tournamentId} and size: ${data.size}`);
+    };
+
+    socket.on('waiting-room-update', handleWaitingRoomUpdate);
+    socket.on('tournament-created', handleTournamentCreated);
+    return () => {
+      socket.off('waiting-room-update', handleWaitingRoomUpdate);
+      socket.off('tournament-created', handleTournamentCreated);
+    };
+  }, [searchParams, socket, users]);
+
+  const me = users.find((u) => u.id === uid);
+  const opponent = users.find((u) => u.id !== uid);
+
+  const isMeFirst = users[0]?.id === uid || !opponent;
   const isOpponentWaiting = !opponent;
 
   const playerProps = {

--- a/src/pages/GameSelectPage/GameMatchingPage/_components/user-card/index.tsx
+++ b/src/pages/GameSelectPage/GameMatchingPage/_components/user-card/index.tsx
@@ -49,7 +49,7 @@ export const UserCard = ({
     if (!isWaiting) {
       return (
         <img
-          src={userAvatar?.trim() || '/assets/sample-avatar.png'}
+          src={userAvatar?.trim() ?? '/assets/sample-avatar.png'}
           alt={isPlayer ? 'user avatar' : 'opponent avatar'}
           className={styles.avatarImage}
         />

--- a/src/pages/GameSelectPage/GameMatchingPage/_components/user-card/index.tsx
+++ b/src/pages/GameSelectPage/GameMatchingPage/_components/user-card/index.tsx
@@ -49,7 +49,7 @@ export const UserCard = ({
     if (!isWaiting) {
       return (
         <img
-          src={userAvatar?.trim() ?? '/assets/sample-avatar.png'}
+          src={userAvatar?.trim() || '/assets/sample-avatar.png'}
           alt={isPlayer ? 'user avatar' : 'opponent avatar'}
           className={styles.avatarImage}
         />


### PR DESCRIPTION
## 🔗 반영 브랜치

- #204 
- `feature/auto-matching → dev` 

## 📝 작업 내용

AUTO SOLO 페이지에 소켓 통신을 추가했습니다.

## 💬 리뷰 요구사항

`UserCard` 컴포넌트가 모든 상황을 대응하지는 못하는 것 같습니다. 대기실에서 플레이어의 모습을 정확하게 보여줄 수 있도록 다음 작업으로 개선해야 할 것 같네요!