### PR TITLE
refactor: sign in 에러 메세지 방식 변경, sign up password 관련 수정

### DIFF
--- a/src/pages/SignInPage/EmailSignInPage/index.tsx
+++ b/src/pages/SignInPage/EmailSignInPage/index.tsx
@@ -31,12 +31,18 @@ export const EmailSignInPage = () => {
           setToken(data.accessToken);
         } catch (error) {
           if (error instanceof HTTPError) {
-            const res = await error.response.json();
-            const message =
-              typeof res.message === 'string'
-                ? res.message.replace(/^body\//, '')
-                : '서버 오류가 발생했습니다.';
-            toast.error(message);
+            try {
+              const res = await error.response.json();
+              const message =
+                typeof res.message === 'string'
+                  ? res.message.replace(/^body\//, '')
+                  : '서버 오류가 발생했습니다.';
+              toast.error(message);
+            } catch {
+              toast.error('서버 응답을 해석하는 중 오류가 발생했습니다.');
+            }
+          } else if (error instanceof Error) {
+            toast.error(error.message);
           } else {
             toast.error('알 수 없는 오류가 발생했습니다.');
           }

--- a/src/pages/SignInPage/EmailSignInPage/index.tsx
+++ b/src/pages/SignInPage/EmailSignInPage/index.tsx
@@ -1,5 +1,7 @@
+import { HTTPError } from 'ky';
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { toast } from 'sonner';
 
 import { useLogin } from '@/api';
 import { useAuthAtom } from '@/atoms/useAuthAtom';
@@ -21,9 +23,21 @@ export const EmailSignInPage = () => {
   const handleSelect = async (index: number) => {
     switch (index) {
       case 0: {
-        const { data } = await mutateAsync({ email, password });
-        if (!data) throw new Error('로그인에 실패했습니다.');
-        setToken(data.accessToken);
+        try {
+          const { data } = await mutateAsync({ email, password });
+
+          if (!data) throw new Error('로그인에 실패했습니다.');
+
+          setToken(data.accessToken);
+        } catch (error) {
+          console.error('로그인 실패:', error);
+
+          if (error instanceof HTTPError) {
+            const res = await error.response.json();
+            const message = res?.message?.replace(/^body\//, '') || 'Failed to sign in';
+            toast.error(message);
+          }
+        }
         break;
       }
       case 1:

--- a/src/pages/SignInPage/EmailSignInPage/index.tsx
+++ b/src/pages/SignInPage/EmailSignInPage/index.tsx
@@ -30,12 +30,15 @@ export const EmailSignInPage = () => {
 
           setToken(data.accessToken);
         } catch (error) {
-          console.error('로그인 실패:', error);
-
           if (error instanceof HTTPError) {
             const res = await error.response.json();
-            const message = res?.message?.replace(/^body\//, '') || 'Failed to sign in';
+            const message =
+              typeof res.message === 'string'
+                ? res.message.replace(/^body\//, '')
+                : '서버 오류가 발생했습니다.';
             toast.error(message);
+          } else {
+            toast.error('알 수 없는 오류가 발생했습니다.');
           }
         }
         break;

--- a/src/pages/SignInPage/index.tsx
+++ b/src/pages/SignInPage/index.tsx
@@ -51,7 +51,7 @@ export const SignInPage = () => {
 
       <DefaultStepNavigator
         ref={navigatorRef}
-        items={['SIGNIN WITH GOOGLE', 'SIGNIN WITH EMAIL', 'GO BACK']}
+        items={['SIGN IN WITH GOOGLE', 'SIGN IN WITH EMAIL', 'GO BACK']}
         onSelect={handleSelect}
         style={{ outline: 'none' }}
       />

--- a/src/pages/SignInPage/index.tsx
+++ b/src/pages/SignInPage/index.tsx
@@ -51,7 +51,7 @@ export const SignInPage = () => {
 
       <DefaultStepNavigator
         ref={navigatorRef}
-        items={['CONTINUE WITH GOOGLE', 'CONTINUE WITH EMAIL', 'GO BACK']}
+        items={['SIGNIN WITH GOOGLE', 'SIGNIN WITH EMAIL', 'GO BACK']}
         onSelect={handleSelect}
         style={{ outline: 'none' }}
       />

--- a/src/pages/SignUpPage/index.tsx
+++ b/src/pages/SignUpPage/index.tsx
@@ -73,6 +73,8 @@ export const SignUpPage = () => {
     handleSelect();
   };
 
+  const isConfirmPasswordValid = confirmPassword.length > 0 && password === confirmPassword;
+
   return (
     <Flex direction="column" justifyContent="space-between" style={{ height: '100%' }}>
       <BackButton />
@@ -129,7 +131,9 @@ export const SignUpPage = () => {
             aria-label={isPasswordValid ? 'Password valid' : 'Password invalid'}
           />
         </div>
-
+        <div id="passwordHint" className={styles.hint}>
+          (8 ~ 20 chars, 1 number, 1 upper, 1 lower, 1 special at least)
+        </div>
         <div className={styles.row}>
           <label className={styles.label} htmlFor="confirmPassword">
             RE-PASSWORD:
@@ -140,6 +144,11 @@ export const SignUpPage = () => {
             value={confirmPassword}
             onChange={(e) => setConfirmPassword(e.target.value)}
             type="password"
+          />
+          <span
+            className={styles.check}
+            data-show={isConfirmPasswordValid ? 'true' : undefined}
+            aria-label={isConfirmPasswordValid ? 'Passwords match' : 'Passwords do not match'}
           />
         </div>
 

--- a/src/pages/SignUpPage/index.tsx
+++ b/src/pages/SignUpPage/index.tsx
@@ -124,6 +124,7 @@ export const SignUpPage = () => {
               validatePassword(value);
             }}
             type="password"
+            aria-describedby="passwordHint"
           />
           <span
             className={styles.check}

--- a/src/pages/SignUpPage/styles.css.ts
+++ b/src/pages/SignUpPage/styles.css.ts
@@ -134,3 +134,11 @@ export const check = style({
     },
   },
 });
+
+export const hint = style({
+  fontSize: rem(15),
+  color: theme.color.orangeChat,
+  marginTop: rem(-13),
+  marginBottom: rem(-10),
+  marginLeft: rem(60),
+});

--- a/src/pages/SignUpPage/styles.css.ts
+++ b/src/pages/SignUpPage/styles.css.ts
@@ -137,7 +137,7 @@ export const check = style({
 
 export const hint = style({
   fontSize: rem(15),
-  color: theme.color.orangeChat,
+  color: theme.color.gray,
   marginTop: rem(-13),
   marginBottom: rem(-10),
   marginLeft: rem(60),

--- a/src/styles/theme.css.ts
+++ b/src/styles/theme.css.ts
@@ -66,6 +66,7 @@ const size = {
 
 const color = {
   white: 'hsl(0, 0%, 100%)',
+  gray: 'hsl(0, 0%, 70%)',
   black: 'hsl(0, 0%, 0%)',
   brand: 'hsl(0, 48%, 59%)',
   orangeChat: 'hsl(14, 97%, 71%)',


### PR DESCRIPTION
## 🔗 반영 브랜치
(#208) feature/SigninServer -> dev

## 📝 작업 내용
1. sign in 페이지에서 서버 메세지 받을 수 있게 수정
2. sign up 페이지에서 유저에제 비밀번호 규칙 알려줄 수 있도록 변경
3. re-password가 password와 일치할 경우 유저에게 일치함을 표시해주도록 변경

![Screenshot from 2025-06-21 20-40-59](https://github.com/user-attachments/assets/5f103f26-a389-4606-9122-cd03e42c36ff)
![Screenshot from 2025-06-21 21-04-29](https://github.com/user-attachments/assets/b558acdc-f480-4501-97c2-6ec0f3136eed)
